### PR TITLE
feat: add length ratio filter and annotation script

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -123,3 +123,31 @@ Other
 ```json
 {"lemma":"gẽ[é]","ipa":"","pos":"v"}
 ```
+
+## Kadé
+
+```
+(Ayo) 2. Tɩ ges pʋg-kõapa la kɩɩbsa yelle A na yɩ sõama wẽndooga sã n tõe wa ne sõngr n kõ pʋg-kõapa la kɩɩbsa tɩ b vɩɩma manege.
+
+(Nyẽe) 3. Yãmb sãn n dɩk a wamdã bɩ a laagã n yõng koom n yũ ?
+
+(Nyẽe) 6. Rũng sẽn deng n dum bãada sãn n wa rũm yãmba ?
+
+53 Appendice Les aspects de notre culture que nous devons comprendre • Les croyances concernant la virginité: est-ce que les gens en sont fiers ou honteux?
+
+Tõnd na n vɩɩmda wãn wãnã?" Dẽe, a ma leok-a lame yaa: "Wẽnnaam na n sõng-d lame." Dẽe, bãmb b yiibã zĩndame n yãbe . Sẽn deng sigra taabo, a Pok baaba maana kaalem. Dẽe, bũudã, zo-rãmbã ne neb wʋsog waame n wa kʋm-ba. A soka a meng yaa: "Maana a wãn tɩ nin- kãensa fãa ka wa m baaba sẽn wa n ya bãada wakate wala b sẽn wa n da ya b yembra wakate?" B saka pʋgẽ, Wẽndoog n be be. Ya wẽndo-kãng taor soaba bala n wa n ges a Pok baaba sẽn deng b kũuma . 8 Kiuug a wãn zugẽ, a Pok ne a ma kẽnga weoogẽ n na n tɩ bao raado. A ma vʋʋsma wa n lebga toogo tɩ ya wa a pãnga saame. Dẽe, a Pok gãda a nugã tɩ b tɩ zĩnd n vʋʋse. A ma yeelame yaa: "Masã, mam ka le tar pãng n tʋmd wa pĩnda ye" .
+```
+
+## SIDA
+
+```
+" Kiiba ", a-t-elle dit, ce qui veut dire " orphelin ". Maman est morte quelques jours plus tard et Poko a donné le nom de Yõdi à l'enfant.
+
+Yembi demande: " Maman, as-tu un secret? " Maman place sa main sur son ventre et dit: " Notre famille devient plus grande. "
+
+Yembi demande: " Maman, as-tu un secret? " Maman place sa main sur son ventre et dit: " Notre famille devient plus grande. "
+
+Yembi s'est alors demandé: " L'homme qui m'a donné ce bracelet, est-ce qu'il essaie de me persuader de coucher avec lui? " Poko, Yembi et Aminata se sont promis qu'elles attendraient le mariage avant d'avoir des rapports sexuels.
+
+A yao-poaka a Yembi zoe n waa a nẽngẽ n bool-a n yeel yaa: "Poko! Poko! M wʋma pagba sẽn gomd bũmb a ye yelle; b yeelame tɩ m ma solga bũmbu. Yaa boẽ la rẽnda? Fo tagsdame tɩ yaa boẽ?"
+```

--- a/src/moore_web/add_len_ratio.py
+++ b/src/moore_web/add_len_ratio.py
@@ -1,0 +1,277 @@
+"""Add length-ratio scores to aligned JSONL files or HuggingFace datasets.
+
+The length ratio is defined as::
+
+    min(len(src), len(tgt)) / max(len(src), len(tgt))
+
+A value of 1.0 means both sides are the same character length; values close to
+0.0 indicate a strong imbalance (e.g. one side is much shorter than the other).
+
+Input
+-----
+Either local JSONL files or a HuggingFace Hub dataset repo ID.
+
+Output (JSONL mode)
+-------------------
+Each input file is re-written in-place (or to ``--output``) with an extra
+``len_ratio`` field per row.
+
+Output (HF mode)
+----------------
+The annotated dataset is pushed to ``--hub-repo`` and/or saved locally to
+``--output`` as JSONL.
+
+Usage
+-----
+    # Annotate a single file in-place
+    uv run python -m moore_web.add_len_ratio final_data_hf/conseils_ministres_aligned.jsonl
+
+    # Annotate all aligned files into a separate directory
+    uv run python -m moore_web.add_len_ratio final_data_hf/*_aligned.jsonl --output final_data_hf_ratio
+
+    # HuggingFace dataset (annotate and push back)
+    uv run python -m moore_web.add_len_ratio --hf-dataset madoss/nllb-mos-lid --hub-repo madoss/nllb-mos-lid-ratio
+
+    # HuggingFace dataset, save locally only
+    uv run python -m moore_web.add_len_ratio --hf-dataset madoss/nllb-mos-lid --output out.jsonl
+
+    # Custom field names
+    uv run python -m moore_web.add_len_ratio data.jsonl --src-field english --tgt-field moore
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Core
+# ---------------------------------------------------------------------------
+
+
+def _len_ratio(src: str, tgt: str) -> float:
+    """Return min(len(src), len(tgt)) / max(len(src), len(tgt)).
+
+    Returns 0.0 when either side is empty.
+    """
+    a, b = len(src), len(tgt)
+    if not a or not b:
+        return 0.0
+    return round(min(a, b) / max(a, b), 4)
+
+
+def _print_stats(scores: list[float], label: str) -> None:
+    print(
+        f"  → {label}  "
+        f"mean={statistics.mean(scores):.4f}  "
+        f"median={statistics.median(scores):.4f}  "
+        f"min={min(scores):.4f}  max={max(scores):.4f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSONL mode
+# ---------------------------------------------------------------------------
+
+
+def annotate_file(
+    path: Path,
+    output_path: Path,
+    src_field: str,
+    tgt_field: str,
+) -> None:
+    rows = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+
+    if not rows:
+        print(f"[skip] {path} — empty file")
+        return
+
+    print(f"Annotating {len(rows)} pairs from {path.name} …")
+    scores = []
+    for row in rows:
+        ratio = _len_ratio(row.get(src_field, "") or "", row.get(tgt_field, "") or "")
+        row["len_ratio"] = ratio
+        scores.append(ratio)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    _print_stats(scores, output_path.name)
+
+
+# ---------------------------------------------------------------------------
+# HuggingFace dataset mode
+# ---------------------------------------------------------------------------
+
+
+def _annotate_batch(batch: dict[str, list], src_field: str, tgt_field: str) -> dict[str, list]:
+    src_texts = batch[src_field]
+    tgt_texts = batch[tgt_field]
+    batch["len_ratio"] = [
+        _len_ratio(s or "", t or "") for s, t in zip(src_texts, tgt_texts)
+    ]
+    return batch
+
+
+def annotate_hf_dataset(
+    source_repo: str,
+    hub_repo: str | None,
+    output: str | None,
+    src_field: str,
+    tgt_field: str,
+    split: str,
+    batch_size: int,
+    private: bool,
+) -> None:
+    from datasets import DatasetDict, load_dataset
+
+    print(f"Loading '{source_repo}' (split={split}) …")
+    ds = load_dataset(source_repo, split=split)
+    print(f"Loaded {len(ds):,} rows.")
+
+    for field in (src_field, tgt_field):
+        if field not in ds.column_names:
+            raise ValueError(f"Column '{field}' not found. Available: {ds.column_names}")
+
+    print("Computing len_ratio …")
+    ds = ds.map(
+        lambda batch: _annotate_batch(batch, src_field, tgt_field),
+        batched=True,
+        batch_size=batch_size,
+        desc="len_ratio",
+    )
+
+    scores = ds["len_ratio"]
+    _print_stats(scores, source_repo)
+
+    if output:
+        print(f"\nWriting {len(ds):,} rows → {output}")
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as f:
+            for row in ds:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        print("Done (local).")
+
+    if hub_repo:
+        print(f"\nPushing {len(ds):,} rows → '{hub_repo}' …")
+        DatasetDict({split: ds}).push_to_hub(hub_repo, private=private)
+        print(f"Done. https://huggingface.co/datasets/{hub_repo}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Add length-ratio scores to aligned JSONL files or HF datasets.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    parser.add_argument(
+        "inputs",
+        nargs="*",
+        metavar="FILE",
+        help="One or more local JSONL files to annotate.",
+    )
+    parser.add_argument(
+        "--hf-dataset",
+        default=None,
+        metavar="REPO_ID",
+        help="HuggingFace Hub dataset repo ID to load (e.g. madoss/nllb-mos-lid). "
+        "Mutually exclusive with FILE positional arguments.",
+    )
+
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Output path. "
+            "JSONL mode — single input: file path; multiple inputs: directory. "
+            "HF mode — local JSONL file to write. "
+            "Default: overwrite inputs in-place (JSONL mode) or skip local write (HF mode)."
+        ),
+    )
+    parser.add_argument(
+        "--hub-repo",
+        default=None,
+        metavar="REPO_ID",
+        help="HF Hub repo to push annotated dataset to (HF mode only).",
+    )
+    parser.add_argument(
+        "--split",
+        default="train",
+        help="Dataset split to load (HF mode only, default: %(default)s).",
+    )
+    parser.add_argument(
+        "--src-field",
+        default="french",
+        help="Field for the source text (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--tgt-field",
+        default="moore",
+        help="Field for the target text (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1000,
+        help="Rows per batch for dataset.map (HF mode only, default: %(default)s).",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Make the pushed HF Hub dataset private (HF mode only).",
+    )
+    args = parser.parse_args()
+
+    if args.hf_dataset and args.inputs:
+        parser.error("FILE arguments and --hf-dataset are mutually exclusive.")
+    if not args.hf_dataset and not args.inputs:
+        parser.error("Provide at least one FILE or use --hf-dataset.")
+
+    if args.hf_dataset:
+        annotate_hf_dataset(
+            source_repo=args.hf_dataset,
+            hub_repo=args.hub_repo,
+            output=args.output,
+            src_field=args.src_field,
+            tgt_field=args.tgt_field,
+            split=args.split,
+            batch_size=args.batch_size,
+            private=args.private,
+        )
+    else:
+        single_input = len(args.inputs) == 1
+        for input_str in args.inputs:
+            input_path = Path(input_str)
+            if not input_path.exists():
+                print(f"[warn] {input_path} not found, skipping.")
+                continue
+            if args.output:
+                out = Path(args.output)
+                out_path = out if single_input else out / input_path.name
+            else:
+                out_path = input_path  # in-place
+            annotate_file(
+                path=input_path,
+                output_path=out_path,
+                src_field=args.src_field,
+                tgt_field=args.tgt_field,
+            )

--- a/src/moore_web/filter_nllb.py
+++ b/src/moore_web/filter_nllb.py
@@ -12,12 +12,13 @@ Filters applied
 8. Parenthesis asymmetry                 — parenthetical content in English absent in Mooré
 9. Number mismatch                       — digit sequences present on one side but not the other
 10. Foreign word list                    — Mooré contains words from non-Mooré GlotLID wordlists
+11. Length ratio                         — min(len(src), len(tgt)) / max(len(src), len(tgt)) below threshold
 
 Quality warnings added per row (before hard filtering)
 -------------------------------------------------------
 ``has_emoji``, ``has_dots_asymmetry``, ``has_number_mismatch``,
 ``has_parenthesis_asymmetry``, ``has_bullet_asymmetry``,
-``has_foreign_words``, ``identification_inconsistency``
+``has_foreign_words``, ``identification_inconsistency``, ``len_ratio``
 
 Usage
 -----
@@ -146,6 +147,18 @@ def _has_parenthesis_asymmetry(src: str, tgt: str) -> bool:
     return bool(src_parens) and not bool(tgt_parens)
 
 
+def _len_ratio(src: str, tgt: str) -> float:
+    """Return min(len(src), len(tgt)) / max(len(src), len(tgt)).
+
+    A ratio close to 1.0 means the two sentences are similar in length.
+    Returns 0.0 when either side is empty.
+    """
+    a, b = len(src), len(tgt)
+    if not a or not b:
+        return 0.0
+    return round(min(a, b) / max(a, b), 4)
+
+
 def _has_bullet_asymmetry(src: str, tgt: str) -> bool:
     """True when a bullet/special char leads one side but not the other."""
     src_first = src.strip()[:1]
@@ -267,6 +280,8 @@ def annotate_warnings(
 
     ``identification_consistency`` is a float in [0, 1]: fraction of Mooré
     tokens that do NOT appear in the foreign (French/English) word list.
+
+    ``len_ratio`` is a float in [0, 1]: min(len(src), len(tgt)) / max(len(src), len(tgt)).
     """
     src_texts = batch[_COL_ENG]
     tgt_texts = batch[_COL_MOS]
@@ -274,6 +289,7 @@ def annotate_warnings(
 
     quality_warnings = []
     id_consistency = []
+    len_ratios = []
 
     for i in range(n):
         src = src_texts[i] or ""
@@ -295,9 +311,11 @@ def annotate_warnings(
 
         quality_warnings.append(warnings)
         id_consistency.append(_lang_consistency_score(tgt, foreign_wordlist))
+        len_ratios.append(_len_ratio(src, tgt))
 
     batch["quality_warnings"] = quality_warnings
     batch["identification_consistency"] = id_consistency
+    batch["len_ratio"] = len_ratios
 
     return batch
 
@@ -318,6 +336,7 @@ def apply_hard_filters(
     filter_parenthesis: bool = False,
     filter_number_mismatch: bool = False,
     consistency_threshold: float = 0.0,
+    len_ratio_threshold: float = 0.0,
 ):
     """Remove rows that fail any hard quality criterion.
 
@@ -337,6 +356,8 @@ def apply_hard_filters(
         consistency_threshold:    Minimum ``identification_consistency`` score (fraction of
                                   Mooré tokens found in the Mooré word list).  0.0 disables
                                   this filter.
+        len_ratio_threshold:      Minimum length ratio min(len(src), len(tgt)) /
+                                  max(len(src), len(tgt)).  0.0 disables this filter.
 
     Returns:
         Filtered HF Dataset.
@@ -416,6 +437,13 @@ def apply_hard_filters(
             lambda r: (r["identification_consistency"] or 0.0) >= consistency_threshold,
         )
 
+    if len_ratio_threshold > 0.0 and "len_ratio" in dataset.column_names:
+        dataset = _track(
+            dataset,
+            "len_ratio",
+            lambda r: (r["len_ratio"] or 0.0) >= len_ratio_threshold,
+        )
+
     after = len(dataset)
     print(f"\nFiltering summary ({before:,} → {after:,} rows kept, {before - after:,} dropped):")
     for name, dropped in stats.items():
@@ -442,6 +470,7 @@ def filter_nllb(
     filter_parenthesis: bool = False,
     filter_number_mismatch: bool = False,
     consistency_threshold: float = 0.0,
+    len_ratio_threshold: float = 0.0,
     load_wordlists: bool = True,
     batch_size: int = 1000,
     private: bool = False,
@@ -463,6 +492,8 @@ def filter_nllb(
         filter_parenthesis:       Drop rows with parenthesis asymmetry.
         filter_number_mismatch:   Drop rows with number mismatch.
         consistency_threshold:    Minimum ``identification_consistency`` score. 0.0 disables.
+        len_ratio_threshold:      Minimum length ratio min(len(src), len(tgt)) /
+                                  max(len(src), len(tgt)). 0.0 disables.
         load_wordlists:           Whether to load GlotLID wordlists.
         batch_size:               Rows per batch for dataset.map.
         private:                  Whether to make the HF Hub dataset private.
@@ -516,6 +547,10 @@ def filter_nllb(
         scores = ds["identification_consistency"]
         mean_score = sum(scores) / len(scores) if scores else 0.0
         print(f"  identification_consistency (mean): {mean_score:.3f}")
+    if "len_ratio" in ds.column_names:
+        ratios = ds["len_ratio"]
+        mean_ratio = sum(ratios) / len(ratios) if ratios else 0.0
+        print(f"  len_ratio (mean): {mean_ratio:.3f}")
 
     # Apply hard filters
     ds = apply_hard_filters(
@@ -529,6 +564,7 @@ def filter_nllb(
         filter_parenthesis=filter_parenthesis,
         filter_number_mismatch=filter_number_mismatch,
         consistency_threshold=consistency_threshold,
+        len_ratio_threshold=len_ratio_threshold,
     )
 
     # Write local output
@@ -634,6 +670,13 @@ def _build_parser() -> argparse.ArgumentParser:
         "word list). 0.0 disables this filter (default: %(default)s).",
     )
     parser.add_argument(
+        "--len-ratio-threshold",
+        type=float,
+        default=0.0,
+        help="Minimum length ratio min(len(src), len(tgt)) / max(len(src), len(tgt)). "
+        "0.0 disables this filter (default: %(default)s).",
+    )
+    parser.add_argument(
         "--no-push",
         dest="push",
         action="store_false",
@@ -673,6 +716,7 @@ def main() -> None:
         filter_parenthesis=args.filter_parenthesis,
         filter_number_mismatch=args.filter_number_mismatch,
         consistency_threshold=args.consistency_threshold,
+        len_ratio_threshold=args.len_ratio_threshold,
         load_wordlists=args.load_wordlists,
         batch_size=args.batch_size,
         private=args.private,


### PR DESCRIPTION
## Summary

- Add `_len_ratio()` to `filter_nllb.py` and compute a `len_ratio` column during annotation; expose `--len-ratio-threshold` as a hard filter in the pipeline
- Add new `moore_web.add_len_ratio` standalone script to annotate local JSONL files or HuggingFace datasets with `len_ratio` scores
- Document new Kadé and SIDA parsing issues in `ISSUES.md`

## Test plan

- [x] Run `uv run python -m moore_web.add_len_ratio final_data_hf/*.jsonl --output final_data_hf_ratio` and verify `len_ratio` field is added to each output file
- [x] Run `uv run python -m moore_web.add_len_ratio --hf-dataset <repo> --output out.jsonl` and verify HF mode works
- [x] Run `filter_nllb` with `--len-ratio-threshold 0.5` and confirm rows with low length ratio are dropped