### PR TITLE
Reapply feat/annotate-module changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,138 @@
 # Mooré Web
 
+A bilingual French/Mooré corpus pipeline: parse → flatten → align → annotate.
+
 ## Installation
 
-### Install `uv` and `pip` dependencies:
+### Install `uv`
 
 ```bash
-# On macOS and Linux
+# macOS / Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# On Windows
+# Windows
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
-# Alternative: using pip
+# Alternative
 pip install uv
 ```
 
-### Justfile
-
-On Linux run the following command
+### Install `just`
 
 ```bash
+# Linux
 apt install just
-```
 
-On Windows run the following command
-
-```powershell
+# Windows
 winget install --id Casey.Just --exact
 ```
 
-Read more on [Just](https://github.com/casey/just)
+See [Just](https://github.com/casey/just) for more details.
 
-### Dependencies Installation
+### Install dependencies
 
 ```bash
 just install
 ```
 
-## TODO List
+## Usage
+
+The CLI is available as `moore-web` after installation.
+
+```bash
+moore-web --help
+```
+
+### Commands
+
+| Command | Description |
+| ------- | ----------- |
+| `parse` | Parse source document(s) to structured JSON |
+| `flatten` | Flatten parsed JSON to a sentence list |
+| `parse-flat` | Parse and flatten in one step |
+| `align` | Align a sentence list using LASER + FastDTW |
+| `annotate` | Enrich an aligned dataset with quality signals |
+| `e2e` | Full pipeline: parse → flatten → align (with optional annotation) |
+
+### Sources
+
+| Source | Description |
+| ------ | ----------- |
+| `sida` | Bilingual SIDA book (single PDF, columns interleaved) |
+| `kade` | Kadé facilitator manuals (two separate PDF/TXT files) |
+| `news` | Raamde news corpus (JSON with `text_units` lists) |
+| `simple` | Simple bilingual dictionary PDF |
+| `conseils` | Conseil-des-ministres bilingual corpus (JSON) |
+
+### Examples
+
+**End-to-end pipeline:**
+
+```bash
+# SIDA book
+moore-web e2e -s sida -i book.pdf -o aligned.json
+
+# Kadé manuals
+moore-web e2e -s kade --fr-input fr.pdf --mo-input mo.pdf -o aligned.json
+
+# News corpus
+moore-web e2e -s news -i corpus.json -o aligned.json
+
+# Push directly to HuggingFace with all annotations
+moore-web e2e -s sida -i book.pdf -o hf://owner/repo --annotate
+```
+
+**Step by step:**
+
+```bash
+# 1. Parse
+moore-web parse -s sida -i book.pdf -o parsed.json
+
+# 2. Flatten
+moore-web flatten -s sida -i parsed.json -o parallel.json
+
+# 3. Align
+moore-web align parallel.json -o aligned.json --min-laser-score 0.6
+```
+
+**Annotate an existing dataset:**
+
+```bash
+# Add specific annotations
+moore-web annotate -i data.jsonl -o out.jsonl --consistency --quality-warn
+
+# Add all annotations
+moore-web annotate -i data.jsonl -o out.jsonl --all
+
+# From/to HuggingFace
+moore-web annotate -i hf://owner/src -o hf://owner/dst --all
+
+# Custom field names with explicit LASER language codes
+moore-web annotate -i data.jsonl -o out.jsonl --src en --tgt mo --laser-score
+moore-web annotate -i data.jsonl -o out.jsonl --src my_col --tgt other_col --laser-score --src-lang fra_Latn --tgt-lang mos_Latn
+```
+
+**Available annotation flags:**
+
+| Flag | Description |
+| ---- | ----------- |
+| `--lang-id` | GlotLID language-ID scores |
+| `--consistency` | Identification consistency score |
+| `--quality-warn` | Quality warnings list |
+| `--laser-score` | LASER cosine similarity |
+| `--comet-qe` | COMET-QE translation quality score |
+| `--all` | Enable all of the above |
+
+**LASER language codes** (`--laser-score` only):
+
+| Flag | Description |
+| ---- | ----------- |
+| `--src-lang` | LASER language code for the source encoder (e.g. `fra`, `eng`, `fra_Latn`). Inferred from `--src` for known fields. |
+| `--tgt-lang` | LASER language code for the target encoder (e.g. `mos`, `mos_Latn`). Inferred from `--tgt` for known fields. |
+
+Known fields resolved automatically: `french`/`fr`/`fra` → `fra`, `english`/`en`/`eng` → `eng`, `moore`/`mo`/`mos` → `mos`. Pass `--src-lang`/`--tgt-lang` explicitly for any other field.
+
+## TODO
 
 - [ ] Add Dioula data and clean it
 - [ ] Add Fulfulde data and clean it

--- a/src/moore_web/align_corpus.py
+++ b/src/moore_web/align_corpus.py
@@ -7,7 +7,7 @@ Pipeline
 1. Encode French and Mooré sentences with LASER (``fra`` / ``mos``)
 2. Run FastDTW on the embeddings to find the monotonic alignment path
 3. Score each aligned pair by cosine similarity
-4. Optionally filter by ``--min-score``
+4. Optionally filter by ``--min-laser-score``
 
 FastDTW naturally handles different lengths (many-to-many), and the
 LASER ``mos_Latn`` model gives good Mooré sentence representations.
@@ -15,7 +15,7 @@ LASER ``mos_Latn`` model gives good Mooré sentence representations.
 Usage
 -----
     uv run python -m moore_web.align_corpus -i parallel.json -o aligned.json
-    uv run python -m moore_web.align_corpus -i parallel.json -o aligned.json --min-score 0.7
+    uv run python -m moore_web.align_corpus -i parallel.json -o aligned.json --min-laser-score 0.7
 
 Input JSON  (ParallelText)
 --------------------------
@@ -136,10 +136,10 @@ if __name__ == "__main__":
         help="Output aligned pairs JSON (default: %(default)s).",
     )
     parser.add_argument(
-        "--min-score",
+        "--min-laser-score",
         type=float,
         default=0.0,
-        help="Keep only pairs with cosine similarity >= this value (default: keep all).",
+        help="Keep only pairs with LASER cosine similarity >= this value (default: keep all).",
     )
     args = parser.parse_args()
 
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     parallel = ParallelText.from_json(raw)
     print(f"Input: {len(parallel.french)} FR sentences, {len(parallel.moore)} MO sentences")
 
-    pairs = align(parallel, min_score=args.min_score)
+    pairs = align(parallel, min_score=args.min_laser_score)
 
     with open(args.output, "wb") as f:
         f.write(msgspec.json.encode(pairs))

--- a/src/moore_web/annotate.py
+++ b/src/moore_web/annotate.py
@@ -1,0 +1,386 @@
+"""Annotation module for aligned bilingual datasets.
+
+Each ``run_*`` function takes a HuggingFace ``Dataset`` and returns an annotated
+``Dataset`` with one or more new columns added.  Functions are composable and
+independent — call only what you need.
+
+IO helpers ``load_data`` / ``save_data`` handle both local JSONL files and
+HuggingFace Hub datasets via ``hf://owner/repo`` URIs.
+
+New columns per function
+------------------------
+- :func:`run_lang_id`          → ``{src}_glotlid_lang``, ``{src}_glotlid_prob``,
+                                  ``{tgt}_glotlid_lang``, ``{tgt}_glotlid_prob``
+                                  (column names derived from ``src_field`` / ``tgt_field``)
+- :func:`run_quality_warnings` → ``quality_warnings`` (list[str]), ``identification_consistency`` (float),
+                                  ``len_ratio`` (float)
+- :func:`run_laser`            → ``laser_score`` (float)
+- :func:`run_comet_qe`         → ``comet_qe`` (float)
+
+Examples
+--------
+    # Local JSONL
+    from moore_web.annotate import load_data, save_data, run_quality_warnings
+    ds = load_data("data.jsonl")
+    ds = run_quality_warnings(ds, src_field="french", tgt_field="moore")
+    save_data(ds, "annotated.jsonl")
+
+    # HuggingFace Hub
+    ds = load_data("hf://owner/repo")
+    ds = run_quality_warnings(ds)
+    save_data(ds, "hf://owner/repo-annotated")
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from datasets import Dataset, DatasetDict, load_dataset  # noqa: F401 — re-exported for monkeypatching
+
+# ---------------------------------------------------------------------------
+# HF URI helpers
+# ---------------------------------------------------------------------------
+
+_HF_PREFIX = "hf://"
+
+
+def _is_hf(path: str) -> bool:
+    return path.startswith(_HF_PREFIX)
+
+
+def _hf_repo(path: str) -> str:
+    return path[len(_HF_PREFIX) :]
+
+
+# ---------------------------------------------------------------------------
+# IO
+# ---------------------------------------------------------------------------
+
+
+def load_data(path: str, split: str = "train"):
+    """Load an aligned dataset from a local JSONL file or a HuggingFace Hub repo.
+
+    Args:
+        path:  Local file path **or** ``hf://owner/repo`` URI.
+        split: Dataset split to load (HF mode only, default: ``"train"``).
+
+    Returns:
+        A ``datasets.Dataset``.
+    """
+
+    if _is_hf(path):
+        repo = _hf_repo(path)
+        print(f"Loading '{repo}' (split={split}) from HuggingFace Hub…")
+        return load_dataset(repo, split=split)
+
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Input file not found: {path}")
+
+    rows: list[dict] = []
+    with p.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+
+    print(f"Loaded {len(rows):,} rows from {p.name}.")
+    return Dataset.from_list(rows)
+
+
+def save_data(dataset, path: str, private: bool = False, split: str = "train") -> None:
+    """Write an annotated dataset to a local JSONL file or push to HuggingFace Hub.
+
+    Args:
+        dataset: A ``datasets.Dataset``.
+        path:    Local file path **or** ``hf://owner/repo`` URI.
+        private: Push as a private dataset (HF mode only).
+        split:   Split name used when wrapping in a ``DatasetDict`` (HF mode only).
+    """
+    if _is_hf(path):
+        repo = _hf_repo(path)
+        print(f"Pushing {len(dataset):,} rows → '{repo}' …")
+        DatasetDict({split: dataset}).push_to_hub(repo, private=private)
+        print(f"Done. https://huggingface.co/datasets/{repo}")
+        return
+
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Writing {len(dataset):,} rows → {out} …")
+    with out.open("w", encoding="utf-8") as f:
+        for row in dataset:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print("Done.")
+
+
+# ---------------------------------------------------------------------------
+# Annotation: GlotLID language identification
+# ---------------------------------------------------------------------------
+
+
+def run_lang_id(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+    batch_size: int = 1000,
+    model=None,
+):
+    """Add GlotLID language-ID predictions for source and target columns.
+
+    Adds four columns derived from the field names:
+    ``{src_field}_glotlid_lang``, ``{src_field}_glotlid_prob``,
+    ``{tgt_field}_glotlid_lang``, ``{tgt_field}_glotlid_prob``.
+
+    Args:
+        dataset:    Input ``datasets.Dataset``.
+        src_field:  Source column name (default: ``"french"``).
+        tgt_field:  Target column name (default: ``"moore"``).
+        batch_size: Rows per batch for model inference.
+        model:      Pre-loaded GlotLID fasttext model; loaded automatically if ``None``.
+
+    Returns:
+        Annotated ``datasets.Dataset``.
+    """
+    from moore_web import glotlid
+
+    if model is None:
+        model = glotlid.load_model()
+
+    print(f"Running GlotLID on '{src_field}' and '{tgt_field}' ({len(dataset):,} rows)…")
+    return glotlid.annotate_dataset(
+        dataset,
+        model=model,
+        source_col=src_field,
+        target_col=tgt_field,
+        batch_size=batch_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Annotation: quality warnings + identification consistency
+# ---------------------------------------------------------------------------
+
+
+def _build_foreign_wordlist(load_wordlists: bool) -> set[str]:
+    """Build the foreign-word exclusion set used by quality-warning checks."""
+    if not load_wordlists:
+        return set()
+
+    from moore_web.wordlists import build_foreign_wordlist
+
+    return build_foreign_wordlist()
+
+
+def run_quality_warnings(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+    load_wordlists: bool = True,
+):
+    """Add quality-warning annotations to each row.
+
+    Adds three columns:
+
+    - ``quality_warnings`` — list of active warning labels
+      (``"emoji"``, ``"dots_asymmetry"``, ``"number_mismatch"``,
+      ``"parenthesis_asymmetry"``, ``"bullet_asymmetry"``, ``"foreign_words"``).
+    - ``identification_consistency`` — float in [0, 1]: fraction of target tokens
+      absent from the foreign word list (higher = more Mooré-consistent).
+    - ``len_ratio`` — float in [0, 1]: ``min(len(src), len(tgt)) / max(len(src), len(tgt))``.
+
+    Args:
+        dataset:        Input ``datasets.Dataset``.
+        src_field:      Source column name (default: ``"french"``).
+        tgt_field:      Target column name (default: ``"moore"``).
+        load_wordlists: Load GlotLID + spellchecker foreign-word lists for richer
+                        detection.  Set to ``False`` to skip (faster, no HF download).
+
+    Returns:
+        Annotated ``datasets.Dataset``.
+    """
+    from moore_web.filter_nllb import annotate_warnings
+
+    foreign_wordlist = _build_foreign_wordlist(load_wordlists)
+
+    print(f"Annotating quality warnings ({len(dataset):,} rows)…")
+    return dataset.map(
+        lambda batch: annotate_warnings(batch, foreign_wordlist, src_col=src_field, tgt_col=tgt_field),
+        batched=True,
+        desc="quality warnings",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Annotation: LASER cosine similarity
+# ---------------------------------------------------------------------------
+
+
+def run_laser(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+    src_lang: str = "fra",
+    tgt_lang: str = "mos",
+    output_field: str | None = None,
+    encoder_src=None,
+    encoder_tgt=None,
+):
+    """Add LASER cosine-similarity scores between source and target sentences.
+
+    Adds one column named ``output_field`` (default: ``"laser_{src_lang}_{tgt_lang}"``).
+
+    Unlike :func:`~moore_web.score_mt_datasets.score_aligned_pairs`, this function
+    does **not** drop rows — it annotates every row unconditionally.
+
+    Args:
+        dataset:      Input ``datasets.Dataset``.
+        src_field:    Source column name (default: ``"french"``).
+        tgt_field:    Target column name (default: ``"moore"``).
+        src_lang:     LASER language code for the source encoder (default: ``"fra"``).
+        tgt_lang:     LASER language code for the target encoder (default: ``"mos"``).
+        output_field: Name for the new score column. Defaults to
+                      ``"laser_{src_lang}_{tgt_lang}"`` when ``None``.
+        encoder_src:  Pre-loaded source encoder; loaded automatically if ``None``.
+        encoder_tgt:  Pre-loaded target encoder; loaded automatically if ``None``.
+
+    Returns:
+        Annotated ``datasets.Dataset``.
+    """
+    from moore_web.score_laser import score_dataset
+
+    return score_dataset(
+        dataset,
+        src_field=src_field,
+        tgt_field=tgt_field,
+        src_lang=src_lang,
+        tgt_lang=tgt_lang,
+        output_field=output_field,
+        encoder_src=encoder_src,
+        encoder_tgt=encoder_tgt,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Annotation: COMET-QE translation quality
+# ---------------------------------------------------------------------------
+
+
+def run_comet_qe(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+    output_field: str | None = None,
+    batch_size: int = 8,
+    gpus: int = 1,
+    model=None,
+):
+    """Add COMET-QE reference-free translation quality scores.
+
+    Adds one column named ``output_field`` (default: ``"comet_qe_{src_field}_{tgt_field}"``).
+
+    Uses ``McGill-NLP/ssa-comet-qe`` (~1.5 GB download on first run).
+
+    Args:
+        dataset:      Input ``datasets.Dataset``.
+        src_field:    Source column name (default: ``"french"``).
+        tgt_field:    Target column name (default: ``"moore"``).
+        output_field: Name for the new score column. Defaults to
+                      ``"comet_qe_{src_field}_{tgt_field}"`` when ``None``.
+        batch_size:   Rows per inference batch.
+        gpus:         Number of GPUs to use (0 = CPU).
+        model:        Pre-loaded COMET model; loaded automatically if ``None``.
+
+    Returns:
+        Annotated ``datasets.Dataset``.
+    """
+    from moore_web.score_comet_qe import score_dataset
+
+    return score_dataset(
+        dataset,
+        src_field=src_field,
+        tgt_field=tgt_field,
+        output_field=output_field,
+        batch_size=batch_size,
+        gpus=gpus,
+        model=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composer
+# ---------------------------------------------------------------------------
+
+
+def annotate(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+    *,
+    lang_id: bool = False,
+    quality_warn: bool = False,
+    consistency: bool = False,
+    laser: bool = False,
+    comet_qe: bool = False,
+    load_wordlists: bool = True,
+    batch_size: int = 1000,
+    comet_batch_size: int = 8,
+    gpus: int = 1,
+    src_lang: str | None = None,
+    tgt_lang: str | None = None,
+):
+    """Run any combination of annotation steps on a dataset.
+
+    ``quality_warn`` and ``consistency`` both call :func:`run_quality_warnings` in a
+    single pass (the foreign wordlist is loaded only once).
+
+    Args:
+        dataset:           Input ``datasets.Dataset``.
+        src_field:         Source column name.
+        tgt_field:         Target column name.
+        lang_id:           Add GlotLID language-ID columns.
+        quality_warn:      Add ``quality_warnings`` column.
+        consistency:       Add ``identification_consistency`` column.
+        laser:             Add ``laser_score`` column.
+        comet_qe:          Add ``comet_qe`` column.
+        load_wordlists:    Load foreign-word lists for quality-warning checks.
+        batch_size:        Rows per batch for lang-ID and warning annotation.
+        comet_batch_size:  Rows per inference batch for COMET-QE.
+        gpus:              Number of GPUs for COMET-QE (0 = CPU).
+        src_lang:          LASER language code for the source encoder. Falls back to
+                           ``FIELD_TO_LANG`` then the ``run_laser`` default.
+        tgt_lang:          LASER language code for the target encoder. Falls back to
+                           ``FIELD_TO_LANG`` then the ``run_laser`` default.
+
+    Returns:
+        Annotated ``datasets.Dataset``.
+    """
+    if lang_id:
+        dataset = run_lang_id(dataset, src_field=src_field, tgt_field=tgt_field, batch_size=batch_size)
+
+    if quality_warn or consistency:
+        dataset = run_quality_warnings(
+            dataset,
+            src_field=src_field,
+            tgt_field=tgt_field,
+            load_wordlists=load_wordlists,
+        )
+
+    if laser:
+        laser_kwargs = {}
+        if src_lang is not None:
+            laser_kwargs["src_lang"] = src_lang
+        if tgt_lang is not None:
+            laser_kwargs["tgt_lang"] = tgt_lang
+        dataset = run_laser(dataset, src_field=src_field, tgt_field=tgt_field, **laser_kwargs)
+
+    if comet_qe:
+        dataset = run_comet_qe(
+            dataset,
+            src_field=src_field,
+            tgt_field=tgt_field,
+            batch_size=comet_batch_size,
+            gpus=gpus,
+        )
+
+    return dataset

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -107,6 +107,55 @@ def _write_aligned(aligned, out: Path, use_jsonl: bool) -> None:
     typer.echo(f"Wrote {len(aligned.french)} aligned pairs → {out}")
 
 
+def _finalize_aligned(
+    aligned,
+    out,  # str | Path
+    jsonl: bool,
+    hf_private: bool,
+    add_lang_id: bool,
+    add_consistency: bool,
+    add_quality_warn: bool,
+    add_laser_score: bool,
+    add_comet_qe: bool,
+) -> None:
+    """Write aligned corpus, optionally annotating and/or pushing to HF Hub."""
+    out_str = str(out)
+    needs_annotation = any([add_lang_id, add_consistency, add_quality_warn, add_laser_score, add_comet_qe])
+    is_hf = out_str.startswith("hf://")
+
+    if needs_annotation or is_hf:
+        from datasets import Dataset
+
+        from moore_web import annotate as _ann
+
+        rows = [
+            {"french": f, "moore": m, "laser_score": s}
+            for f, m, s in zip(aligned.french, aligned.moore, aligned.scores)
+        ]
+        if aligned.english:
+            for row, en in zip(rows, aligned.english):
+                row["english"] = en
+        dataset = Dataset.from_list(rows)
+
+        if needs_annotation:
+            dataset = _ann.annotate(
+                dataset,
+                lang_id=add_lang_id,
+                quality_warn=add_quality_warn,
+                consistency=add_consistency,
+                laser=add_laser_score,
+                comet_qe=add_comet_qe,
+            )
+            if not add_quality_warn and "quality_warnings" in dataset.column_names:
+                dataset = dataset.remove_columns(["quality_warnings"])
+            if not add_consistency and "identification_consistency" in dataset.column_names:
+                dataset = dataset.remove_columns(["identification_consistency"])
+
+        _ann.save_data(dataset, out_str, private=hf_private)
+    else:
+        _write_aligned(aligned, Path(out_str), jsonl)
+
+
 def _dedup_aligned(aligned):
     """Deduplicate an AlignedCorpus using COMET-QE and return a new one."""
     from moore_web.dedup_aligned_comet import deduplicate_by_comet
@@ -271,7 +320,7 @@ def parse(
         corpus = json.loads(input.read_text(encoding="utf-8"))
 
         if lang_id:
-            from moore_web.lang_id import annotate_text_units
+            from moore_web.glotlid import annotate_text_units
 
             typer.echo("Running language ID…")
             corpus = annotate_text_units(corpus)
@@ -509,7 +558,7 @@ def parse_flat(
         corpus = json.loads(input.read_text(encoding="utf-8"))
 
         if lang_id:
-            from moore_web.lang_id import annotate_text_units
+            from moore_web.glotlid import annotate_text_units
 
             typer.echo("Running language ID…")
             corpus = annotate_text_units(corpus)
@@ -557,7 +606,7 @@ def align(
     ] = None,
     min_score: Annotated[
         float,
-        typer.Option("--min-score", min=0.0, max=1.0, help="Drop pairs below this cosine similarity."),
+        typer.Option("--min-laser-score", min=0.0, max=1.0, help="Drop pairs below this LASER cosine similarity."),
     ] = 0.0,
     jsonl: Annotated[
         bool,
@@ -566,7 +615,7 @@ def align(
 ) -> None:
     """Align a ParallelText JSON using LASER embeddings + FastDTW.
 
-    Example: moore-web align parallel.json -o aligned.json --min-score 0.6
+    Example: moore-web align parallel.json -o aligned.json --min-laser-score 0.6
     """
     from moore_web.align_corpus import align as _align
     from moore_web.flatten import ParallelText
@@ -587,6 +636,89 @@ def align(
 
 
 # ---------------------------------------------------------------------------
+# annotate
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def annotate(
+    input: Annotated[str, typer.Option("--input", "-i", help="Local JSONL or hf://owner/repo.")],
+    output: Annotated[str, typer.Option("--output", "-o", help="Local JSONL or hf://owner/repo.")],
+    src: Annotated[str, typer.Option("--src", help="Source field name in the dataset.")] = "french",
+    tgt: Annotated[str, typer.Option("--tgt", help="Target field name in the dataset.")] = "moore",
+    lang_id: Annotated[
+        bool, typer.Option("--lang-id", is_flag=True, help="Add GlotLID language-ID scores.")
+    ] = False,
+    consistency: Annotated[
+        bool, typer.Option("--consistency", is_flag=True, help="Add identification_consistency score.")
+    ] = False,
+    quality_warn: Annotated[
+        bool, typer.Option("--quality-warn", is_flag=True, help="Add quality_warnings list.")
+    ] = False,
+    laser_score: Annotated[
+        bool, typer.Option("--laser-score", is_flag=True, help="Add LASER cosine similarity.")
+    ] = False,
+    src_lang: Annotated[
+        Optional[str],
+        typer.Option("--src-lang", help="LASER language code for the source encoder (e.g. fra, eng). "
+                     "Inferred from --src when known; required for unrecognized fields."),
+    ] = None,
+    tgt_lang: Annotated[
+        Optional[str],
+        typer.Option("--tgt-lang", help="LASER language code for the target encoder (e.g. mos). "
+                     "Inferred from --tgt when known; required for unrecognized fields."),
+    ] = None,
+    comet_qe: Annotated[
+        bool, typer.Option("--comet-qe", is_flag=True, help="Add COMET-QE translation quality score.")
+    ] = False,
+    all_annotations: Annotated[
+        bool, typer.Option("--all", is_flag=True, help="Enable all annotation flags.")
+    ] = False,
+    hf_private: Annotated[
+        bool, typer.Option("--hf-private", is_flag=True, help="Push to HuggingFace as private dataset.")
+    ] = False,
+) -> None:
+    """Enrich an aligned dataset with quality signals.
+
+    All annotation flags are off by default — opt in to what you need.
+
+    [bold]Local:[/bold]  moore-web annotate -i data.jsonl -o out.jsonl --consistency --quality-warn
+    [bold]All:[/bold]    moore-web annotate -i data.jsonl -o out.jsonl --all
+    [bold]HF:[/bold]     moore-web annotate -i hf://owner/src -o hf://owner/dst --all
+    """
+    from moore_web import annotate as _ann
+
+    if all_annotations:
+        lang_id = consistency = quality_warn = laser_score = comet_qe = True
+
+    if not any([lang_id, consistency, quality_warn, laser_score, comet_qe]):
+        _err("No annotation flags specified. Pass at least one of: --lang-id, --consistency, "
+             "--quality-warn, --laser-score, --comet-qe.")
+        raise typer.Exit(1)
+
+    dataset = _ann.load_data(input)
+    dataset = _ann.annotate(
+        dataset,
+        src_field=src,
+        tgt_field=tgt,
+        lang_id=lang_id,
+        quality_warn=quality_warn,
+        consistency=consistency,
+        laser=laser_score,
+        comet_qe=comet_qe,
+        src_lang=src_lang,
+        tgt_lang=tgt_lang,
+    )
+    # Drop the column not requested when only one of the shared pair is selected.
+    if not quality_warn and "quality_warnings" in dataset.column_names:
+        dataset = dataset.remove_columns(["quality_warnings"])
+    if not consistency and "identification_consistency" in dataset.column_names:
+        dataset = dataset.remove_columns(["identification_consistency"])
+
+    _ann.save_data(dataset, output, private=hf_private)
+
+
+# ---------------------------------------------------------------------------
 # e2e
 # ---------------------------------------------------------------------------
 
@@ -601,7 +733,12 @@ def e2e(
             "-i",
             exists=True,
             dir_okay=False,
-            help="Input file (sida PDF, news JSON, or simple PDF).",
+            help=(
+                "Input file (sida PDF, news/conseils JSON, or simple PDF). "
+                "Must be a local path. For news/conseils corpora hosted on HuggingFace, "
+                "download the file first: "
+                "huggingface-cli download owner/repo corpus.json --repo-type dataset --local-dir ."
+            ),
         ),
     ] = None,
     fr_input: Annotated[
@@ -613,8 +750,8 @@ def e2e(
         typer.Option("--mo-input", exists=True, dir_okay=False, help="Mooré PDF/TXT (kade only)."),
     ] = None,
     output: Annotated[
-        Optional[Path],
-        typer.Option("--output", "-o", help="Output aligned JSON (default: derived from input)."),
+        Optional[str],
+        typer.Option("--output", "-o", help="Output path or hf://owner/repo (default: derived from input)."),
     ] = None,
     segment: Annotated[
         bool,
@@ -622,7 +759,7 @@ def e2e(
     ] = True,
     min_score: Annotated[
         float,
-        typer.Option("--min-score", min=0.0, max=1.0, help="Drop pairs below this cosine similarity."),
+        typer.Option("--min-laser-score", min=0.0, max=1.0, help="Drop pairs below this LASER cosine similarity."),
     ] = 0.0,
     lang_id: Annotated[
         bool,
@@ -656,6 +793,34 @@ def e2e(
         bool,
         typer.Option("--jsonl", is_flag=True, help="Write output as JSONL instead of JSON."),
     ] = False,
+    add_lang_id: Annotated[
+        bool,
+        typer.Option("--add-lang-id", is_flag=True, help="Annotate aligned output with GlotLID scores."),
+    ] = False,
+    add_consistency: Annotated[
+        bool,
+        typer.Option("--add-consistency", is_flag=True, help="Annotate aligned output with identification_consistency."),
+    ] = False,
+    add_quality_warn: Annotated[
+        bool,
+        typer.Option("--add-quality-warn", is_flag=True, help="Annotate aligned output with quality_warnings."),
+    ] = False,
+    add_laser_score: Annotated[
+        bool,
+        typer.Option("--add-laser-score", is_flag=True, help="Annotate aligned output with LASER similarity."),
+    ] = False,
+    add_comet_qe: Annotated[
+        bool,
+        typer.Option("--add-comet-qe", is_flag=True, help="Annotate aligned output with COMET-QE score."),
+    ] = False,
+    do_annotate: Annotated[
+        bool,
+        typer.Option("--annotate", is_flag=True, help="Shorthand: enable all --add-* annotation flags."),
+    ] = False,
+    hf_private: Annotated[
+        bool,
+        typer.Option("--hf-private", is_flag=True, help="Push to HuggingFace as private dataset."),
+    ] = False,
 ) -> None:
     """End-to-end pipeline: parse → flatten → align.
 
@@ -663,7 +828,20 @@ def e2e(
     [bold]kade:[/bold]    moore-web e2e -s kade --fr-input fr.pdf --mo-input mo.pdf -o aligned.json
     [bold]news:[/bold]    moore-web e2e -s news -i corpus.json -o aligned.json
     [bold]simple:[/bold]  moore-web e2e -s simple -i dict.pdf -o aligned.json
+    [bold]HF output:[/bold] moore-web e2e -s sida -i book.pdf -o hf://owner/repo --annotate
     """
+    if do_annotate:
+        add_lang_id = add_consistency = add_quality_warn = add_laser_score = add_comet_qe = True
+
+    _ann_kwargs: dict = dict(
+        add_lang_id=add_lang_id,
+        add_consistency=add_consistency,
+        add_quality_warn=add_quality_warn,
+        add_laser_score=add_laser_score,
+        add_comet_qe=add_comet_qe,
+        hf_private=hf_private,
+    )
+
     from moore_web.align_corpus import align as _align
     from moore_web.flatten import (
         flatten_facilitateur_pair,
@@ -704,7 +882,7 @@ def e2e(
         corpus = json.loads(input.read_text(encoding="utf-8"))
 
         if lang_id:
-            from moore_web.lang_id import annotate_text_units
+            from moore_web.glotlid import annotate_text_units
 
             typer.echo("      Running language ID…")
             corpus = annotate_text_units(corpus)
@@ -751,7 +929,7 @@ def e2e(
         )
         if drop_duplicate:
             aligned = _dedup_aligned(aligned)
-        _write_aligned(aligned, out, jsonl)
+        _finalize_aligned(aligned, out, jsonl, **_ann_kwargs)
         return
 
     elif source == Source.simple:
@@ -768,7 +946,7 @@ def e2e(
             pages = parse_doc(doc)
         typer.echo("[2/2] Flattening…")
 
-        def _write_simple(inc_examples: bool, inc_entries: bool, dest: Path) -> None:
+        def _write_simple(inc_examples: bool, inc_entries: bool, dest) -> None:
             p = flatten_simple_parser(pages, include_examples=inc_examples, include_entries=inc_entries)
             typer.echo(f"      FR: {len(p.french)}  MO: {len(p.moore)}  EN: {len(p.english)}  → {dest}")
             a = AlignedCorpus(
@@ -778,7 +956,7 @@ def e2e(
                 scores=[1.0] * len(p.french),
                 source=p.source,
             )
-            _write_aligned(a, dest, jsonl)
+            _finalize_aligned(a, dest, jsonl, **_ann_kwargs)
 
         out = output or _default_output(input, f"_aligned{_ext}")
         if entries_output is not None:
@@ -836,7 +1014,7 @@ def e2e(
         )
         if drop_duplicate:
             aligned = _dedup_aligned(aligned)
-        _write_aligned(aligned, out, jsonl)
+        _finalize_aligned(aligned, out, jsonl, **_ann_kwargs)
         return
 
     typer.echo(f"      FR: {len(parallel.french)} sentences  MO: {len(parallel.moore)} sentences")
@@ -848,7 +1026,7 @@ def e2e(
     if drop_duplicate:
         aligned = _dedup_aligned(aligned)
 
-    _write_aligned(aligned, out, jsonl)
+    _finalize_aligned(aligned, out, jsonl, **_ann_kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/moore_web/filter_nllb.py
+++ b/src/moore_web/filter_nllb.py
@@ -13,6 +13,7 @@ Filters applied
 9. Number mismatch                       — digit sequences present on one side but not the other
 10. Foreign word list                    — Mooré contains words from non-Mooré GlotLID wordlists
 11. Length ratio                         — min(len(src), len(tgt)) / max(len(src), len(tgt)) below threshold
+12. Terminal punctuation                 — OpusFilter-style mismatch in ``.``, ``?``, ``!``, ``…`` counts
 
 Quality warnings added per row (before hard filtering)
 -------------------------------------------------------
@@ -41,9 +42,12 @@ Usage
 from __future__ import annotations
 
 import argparse
+import math
 import re
 
 from dotenv import load_dotenv
+
+from moore_web.wordlists import build_foreign_wordlist
 
 try:
     from datatrove.utils.text import TextNormConfig, simplify_text as _simplify_text
@@ -198,61 +202,24 @@ def _lang_consistency_score(text: str, foreign_words: set[str]) -> float:
 # ---------------------------------------------------------------------------
 
 
-def _load_glotlid_wordlists(languages: list[str]) -> set[str]:
-    """Load word lists from ``madoss/mos-eng-fra-wordlists`` for the given language configs.
+def _terminal_punctuation_score(src: str, tgt: str) -> float:
+    """Return an OpusFilter-style terminal punctuation score.
 
-    Each language is a separate dataset config (e.g. ``"fra_Latn"``).
-    Returns a flat union of all words across the requested languages.
+    Borrowed from OpusFilter's ``TerminalPunctuationFilter``
+    (vazquez-etal-2019-university). Counts ``.``, ``?``, ``!``, ``…`` across
+    the full sentence (not just the end).
+    Score = ``-log(abs(spun - tpun) + extra_penalty + 1)`` where *extra_penalty*
+    accounts for each side having more than one terminal punctuation mark.
+    Score of ``0.0`` means a perfect match; more negative = worse.
     """
-    try:
-        from datasets import load_dataset
-    except ImportError:
-        print("Warning: 'datasets' not installed — skipping wordlist filter.")
-        return set()
-
-    words: set[str] = set()
-    for lang in languages:
-        try:
-            ds = load_dataset("madoss/mos-eng-fra-wordlists", split=lang)
-            for row in ds:
-                word = row.get("text") or row.get("word", "")
-                if word:
-                    words.add(word.lower())
-            print(f"  Loaded {lang} wordlist ({len(words):,} words total so far).")
-        except Exception as e:
-            print(f"Warning: could not load glotlid-wordlists[{lang}] ({e}) — skipping.")
-    return words
-
-
-# GlotLID language code → pyspellchecker language code
-_SPELLCHECKER_LANG_MAP = {"fra_Latn": "fr", "eng_Latn": "en", "spa_Latn": "es", "deu_Latn": "de"}
-
-
-def _load_spellchecker_words(languages: list[str]) -> set[str]:
-    """Load full vocabulary from pyspellchecker for the given GlotLID language codes.
-
-    pyspellchecker ships with comprehensive word-frequency dictionaries (~100k+ words),
-    unlike the GlotLID discriminative lists (~14–25k n-grams).  This catches common
-    words like 'comment', 'game', 'pesée' that GlotLID lists omit.
-    """
-    try:
-        from spellchecker import SpellChecker
-    except ImportError:
-        print("Warning: 'pyspellchecker' not installed — falling back to GlotLID wordlists only.")
-        return set()
-
-    words: set[str] = set()
-    for lang in languages:
-        sc_lang = _SPELLCHECKER_LANG_MAP.get(lang)
-        if sc_lang is None:
-            continue
-        try:
-            sc = SpellChecker(language=sc_lang)
-            words.update(sc.word_frequency.keys())
-            print(f"  Loaded spellchecker[{sc_lang}] ({len(words):,} words total so far).")
-        except Exception as e:
-            print(f"Warning: could not load spellchecker[{sc_lang}] ({e}) — skipping.")
-    return words
+    spun = sum(c in ".?!…" for c in src)
+    tpun = sum(c in ".?!…" for c in tgt)
+    score = abs(spun - tpun)
+    if spun > 1:
+        score += spun - 1
+    if tpun > 1:
+        score += tpun - 1
+    return -math.log(score + 1)
 
 
 def _has_foreign_words(text: str, wordlist: set[str]) -> bool:
@@ -271,20 +238,29 @@ def _has_foreign_words(text: str, wordlist: set[str]) -> bool:
 def annotate_warnings(
     batch: dict[str, list],
     foreign_wordlist: set[str],
+    src_col: str = _COL_ENG,
+    tgt_col: str = _COL_MOS,
 ) -> dict[str, list]:
     """Add ``quality_warnings`` and ``identification_consistency`` columns.
 
     ``quality_warnings`` is a ``list[str]`` of active warning labels per row:
       ``"emoji"``, ``"dots_asymmetry"``, ``"number_mismatch"``,
-      ``"parenthesis_asymmetry"``, ``"bullet_asymmetry"``, ``"foreign_words"``
+      ``"parenthesis_asymmetry"``, ``"bullet_asymmetry"``, ``"foreign_words"``,
+      ``"terminal_punctuation"``
 
     ``identification_consistency`` is a float in [0, 1]: fraction of Mooré
     tokens that do NOT appear in the foreign (French/English) word list.
 
     ``len_ratio`` is a float in [0, 1]: min(len(src), len(tgt)) / max(len(src), len(tgt)).
+
+    Args:
+        batch:            Batched dict of column lists.
+        foreign_wordlist: Set of foreign tokens to check against.
+        src_col:          Column name for the source text (default: ``"eng_Latn"``).
+        tgt_col:          Column name for the target text (default: ``"mos_Latn"``).
     """
-    src_texts = batch[_COL_ENG]
-    tgt_texts = batch[_COL_MOS]
+    src_texts = batch[src_col]
+    tgt_texts = batch[tgt_col]
     n = len(src_texts)
 
     quality_warnings = []
@@ -308,6 +284,8 @@ def annotate_warnings(
             warnings.append("bullet_asymmetry")
         if _has_foreign_words(tgt, foreign_wordlist):
             warnings.append("foreign_words")
+        if _terminal_punctuation_score(src, tgt) < -2:
+            warnings.append("terminal_punctuation")
 
         quality_warnings.append(warnings)
         id_consistency.append(_lang_consistency_score(tgt, foreign_wordlist))
@@ -507,20 +485,11 @@ def filter_nllb(
     # Load wordlists
     foreign_wordlist: set[str] = set()
     if load_wordlists:
-        # GlotLID discriminative n-grams (~14–25k, misses common words like 'comment', 'game')
-        glotlid_foreign = _load_glotlid_wordlists(["fra_Latn", "eng_Latn"])
-        # pyspellchecker full dictionaries (~100k+, covers common vocabulary)
-        spell_foreign = _load_spellchecker_words(["fra_Latn", "eng_Latn"])
-        raw_foreign = glotlid_foreign | spell_foreign
-        moore_wordlist = _load_glotlid_wordlists(["mos_Latn"])
         # NOTE: the GlotLID Mooré wordlist is very small (~1 000 discriminative n-grams),
         # so it cannot be used to positively identify Mooré words.  We use it only to
         # subtract any overlap from the foreign wordlist, avoiding false positives for
         # loanwords or short tokens shared between languages.
-        foreign_wordlist = raw_foreign - moore_wordlist
-        print(
-            f"  Exclusive foreign wordlist: {len(foreign_wordlist):,} words ({len(raw_foreign) - len(foreign_wordlist):,} removed as Mooré overlap)."
-        )
+        foreign_wordlist = build_foreign_wordlist()
 
     # Annotate quality warnings
     print("Annotating quality warnings…")

--- a/src/moore_web/glotlid.py
+++ b/src/moore_web/glotlid.py
@@ -37,7 +37,7 @@ def predict(model: fasttext.FastText._FastText, texts: list[str], k: int = 1) ->
     labels, probs = model.predict(cleaned, k=k)
     # labels are like ['__label__mos_Latn'], strip the prefix
     langs = pd.Series([line[0].replace("__label__", "") for line in labels], name="predicted_language")
-    scores = pd.Series([p[0] for p in probs], name="predicted_probability")
+    scores = pd.Series([round(float(p[0]), 4) for p in probs], name="predicted_probability")
     return langs, scores
 
 
@@ -60,20 +60,25 @@ def annotate_dataset(
 ):
     """Add GlotLID predictions to a HuggingFace Dataset.
 
-    Adds four new columns:
-      source_glotlid_lang, source_glotlid_prob,
-      target_glotlid_lang, target_glotlid_prob.
+    Adds four new columns derived from the input column names:
+      ``{source_col}_glotlid_lang``, ``{source_col}_glotlid_prob``,
+      ``{target_col}_glotlid_lang``, ``{target_col}_glotlid_prob``.
     """
     if model is None:
         model = load_model()
 
+    src_lang_col = f"{source_col}_glotlid_lang"
+    src_prob_col = f"{source_col}_glotlid_prob"
+    tgt_lang_col = f"{target_col}_glotlid_lang"
+    tgt_prob_col = f"{target_col}_glotlid_prob"
+
     def _batch_predict(batch):
         src_langs, src_probs = predict(model, batch[source_col])
         tgt_langs, tgt_probs = predict(model, batch[target_col])
-        batch["source_glotlid_lang"] = src_langs.tolist()
-        batch["source_glotlid_prob"] = src_probs.tolist()
-        batch["target_glotlid_lang"] = tgt_langs.tolist()
-        batch["target_glotlid_prob"] = tgt_probs.tolist()
+        batch[src_lang_col] = src_langs.tolist()
+        batch[src_prob_col] = src_probs.tolist()
+        batch[tgt_lang_col] = tgt_langs.tolist()
+        batch[tgt_prob_col] = tgt_probs.tolist()
         return batch
 
     return dataset.map(_batch_predict, batched=True, batch_size=batch_size, load_from_cache_file=False)

--- a/src/moore_web/score_comet_qe.py
+++ b/src/moore_web/score_comet_qe.py
@@ -49,6 +49,45 @@ def load_model():
     return load_from_checkpoint(download_model("McGill-NLP/ssa-comet-qe"))
 
 
+def score_dataset(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+    output_field: str | None = None,
+    batch_size: int = 8,
+    gpus: int = 1,
+    model=None,
+):
+    """Add COMET-QE scores to every row of a HuggingFace ``Dataset``.
+
+    Args:
+        dataset:      Input ``datasets.Dataset``.
+        src_field:    Source column name (default: ``"french"``).
+        tgt_field:    Target column name (default: ``"moore"``).
+        output_field: Name of the new score column. Defaults to
+                      ``"comet_qe_{src_field}_{tgt_field}"`` when ``None``.
+        batch_size:   Rows per inference batch.
+        gpus:         Number of GPUs to use (0 = CPU).
+        model:        Pre-loaded COMET model; loaded automatically if ``None``.
+
+    Returns:
+        Annotated ``datasets.Dataset`` with an added score column.
+    """
+    if output_field is None:
+        output_field = f"comet_qe_{src_field}_{tgt_field}"
+    if model is None:
+        model = load_model()
+
+    def _score_batch(batch: dict) -> dict:
+        data = [{"src": s, "mt": t} for s, t in zip(batch[src_field], batch[tgt_field])]
+        output = model.predict(data, batch_size=batch_size, gpus=gpus)
+        batch[output_field] = [round(float(s), 4) for s in output.scores]
+        return batch
+
+    print(f"Scoring {len(dataset):,} pairs with COMET-QE…")
+    return dataset.map(_score_batch, batched=True, desc="comet-qe")
+
+
 def score_file(
     path: Path,
     output_path: Path,
@@ -57,6 +96,7 @@ def score_file(
     batch_size: int,
     gpus: int,
     model,
+    output_field: str | None = None,
 ) -> None:
     rows = []
     with open(path, encoding="utf-8") as f:
@@ -69,13 +109,16 @@ def score_file(
         print(f"[skip] {path} — empty file")
         return
 
+    if output_field is None:
+        output_field = f"comet_qe_{src_field}_{mt_field}"
+
     data = [{"src": r[src_field], "mt": r[mt_field]} for r in rows]
 
     print(f"Scoring {len(data)} pairs from {path.name} …")
     output = model.predict(data, batch_size=batch_size, gpus=gpus)
 
     for row, qe_score in zip(rows, output.scores):
-        row["comet_qe"] = round(float(qe_score), 4)
+        row[output_field] = round(float(qe_score), 4)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:

--- a/src/moore_web/score_laser.py
+++ b/src/moore_web/score_laser.py
@@ -1,0 +1,124 @@
+"""Compute LASER cosine-similarity scores for aligned bilingual datasets.
+
+Provides a dataset-level API (``score_dataset``) that annotates every row
+without dropping any pairs, and a lower-level ``load_encoders`` helper for
+reusing already-loaded models.
+
+See also ``score_mt_datasets.score_aligned_pairs`` for a list-based API that
+filters pairs below a minimum score and returns an ``AlignedCorpus``.
+
+Usage
+-----
+    from moore_web.score_laser import score_dataset
+    ds = score_dataset(dataset, src_field="french", tgt_field="moore")
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Known field-name → LASER language code mappings for this project.
+# Only covers our use-case columns; for any other field the caller must
+# pass the correct LASER code explicitly via src_lang / tgt_lang.
+_FIELD_TO_LANG: dict[str, str] = {
+    # French
+    "french": "fra",
+    "fr": "fra",
+    "fra": "fra",
+    "fra_Latn": "fra_Latn",
+    # English
+    "english": "eng",
+    "en": "eng",
+    "eng": "eng",
+    "eng_Latn": "eng_Latn",
+    # Mooré
+    "moore": "mos",
+    "mooré": "mos",
+    "mo": "mos",
+    "mos": "mos",
+    "mos_Latn": "mos_Latn",
+}
+
+
+def load_encoders(src_lang: str = "fra", tgt_lang: str = "mos"):
+    """Load and return a (src_encoder, tgt_encoder) pair.
+
+    Args:
+        src_lang: LASER language code for the source side (default: ``"fra"``).
+        tgt_lang: LASER language code for the target side (default: ``"mos"``).
+
+    Returns:
+        A ``(laser_src, laser_tgt)`` tuple of ``LaserEncoderPipeline`` instances.
+    """
+    from laser_encoders import LaserEncoderPipeline
+
+    print(f"Loading LASER {src_lang} model…")
+    laser_src = LaserEncoderPipeline(lang=src_lang)
+    print(f"Loading LASER {tgt_lang} model…")
+    laser_tgt = LaserEncoderPipeline(lang=tgt_lang)
+    return laser_src, laser_tgt
+
+
+def score_dataset(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+    src_lang: str | None = None,
+    tgt_lang: str | None = None,
+    output_field: str | None = None,
+    encoder_src=None,
+    encoder_tgt=None,
+):
+    """Add LASER cosine-similarity scores to every row of a HuggingFace ``Dataset``.
+
+    Annotates all rows unconditionally — no rows are dropped.  For a
+    filtering variant see ``score_mt_datasets.score_aligned_pairs``.
+
+    Language codes are resolved in this order:
+    1. Explicit ``src_lang`` / ``tgt_lang`` arguments (highest priority).
+    2. ``_FIELD_TO_LANG`` lookup on the field name (covers our known columns).
+    3. ``ValueError`` if neither resolves — the caller must pass the lang code.
+
+    Args:
+        dataset:      Input ``datasets.Dataset``.
+        src_field:    Source column name (default: ``"french"``).
+        tgt_field:    Target column name (default: ``"moore"``).
+        src_lang:     LASER language code for the source encoder. Inferred from
+                      ``src_field`` when ``None``.
+        tgt_lang:     LASER language code for the target encoder. Inferred from
+                      ``tgt_field`` when ``None``.
+        output_field: Name of the new score column. Defaults to
+                      ``"laser_{src_lang}_{tgt_lang}"`` when ``None``.
+        encoder_src:  Pre-loaded source ``LaserEncoderPipeline``; loaded
+                      automatically if ``None``.
+        encoder_tgt:  Pre-loaded target ``LaserEncoderPipeline``; loaded
+                      automatically if ``None``.
+
+    Returns:
+        Annotated ``datasets.Dataset`` with an added score column.
+    """
+    src_lang = src_lang or _FIELD_TO_LANG.get(src_field)
+    tgt_lang = tgt_lang or _FIELD_TO_LANG.get(tgt_field)
+
+    if src_lang is None:
+        raise ValueError(f"Cannot infer LASER lang for src_field={src_field!r}. Pass src_lang explicitly.")
+    if tgt_lang is None:
+        raise ValueError(f"Cannot infer LASER lang for tgt_field={tgt_field!r}. Pass tgt_lang explicitly.")
+
+    if output_field is None:
+        output_field = f"laser_{src_lang}_{tgt_lang}"
+
+    if encoder_src is None or encoder_tgt is None:
+        encoder_src, encoder_tgt = load_encoders(src_lang, tgt_lang)
+
+    src_texts: list[str] = dataset[src_field]
+    tgt_texts: list[str] = dataset[tgt_field]
+
+    print(f"Encoding {len(src_texts):,} source sentences…")
+    src_embs: np.ndarray = encoder_src.encode_sentences(src_texts, normalize_embeddings=True)
+    print(f"Encoding {len(tgt_texts):,} target sentences…")
+    tgt_embs: np.ndarray = encoder_tgt.encode_sentences(tgt_texts, normalize_embeddings=True)
+
+    # Dot product on unit vectors == cosine similarity
+    scores = [round(float(s), 4) for s in (src_embs * tgt_embs).sum(axis=1).tolist()]
+    return dataset.add_column(output_field, scores)

--- a/src/moore_web/segment_news_data.py
+++ b/src/moore_web/segment_news_data.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         corpus = json.load(f)
 
     if not args.no_lang_id:
-        from moore_web.lang_id import annotate_text_units
+        from moore_web.glotlid import annotate_text_units
 
         corpus = annotate_text_units(corpus)
 

--- a/src/moore_web/wordlists.py
+++ b/src/moore_web/wordlists.py
@@ -1,0 +1,101 @@
+"""Word-list loading utilities for language-quality filtering.
+
+Provides helpers to fetch GlotLID discriminative n-gram lists and
+pyspellchecker full-vocabulary dictionaries, plus a high-level builder
+that constructs the foreign-word exclusion set used by quality-warning
+checks.
+"""
+
+from __future__ import annotations
+
+# GlotLID language code → pyspellchecker language code
+_SPELLCHECKER_LANG_MAP = {"fra_Latn": "fr", "eng_Latn": "en", "spa_Latn": "es", "deu_Latn": "de"}
+
+
+def load_glotlid_wordlists(languages: list[str]) -> set[str]:
+    """Load word lists from ``madoss/mos-eng-fra-wordlists`` for the given language configs.
+
+    Each language is a separate dataset config (e.g. ``"fra_Latn"``).
+    Returns a flat union of all words across the requested languages.
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        print("Warning: 'datasets' not installed — skipping wordlist filter.")
+        return set()
+
+    words: set[str] = set()
+    for lang in languages:
+        try:
+            ds = load_dataset("madoss/mos-eng-fra-wordlists", split=lang)
+            for row in ds:
+                word = row.get("text") or row.get("word", "")
+                if word:
+                    words.add(word.lower())
+            print(f"  Loaded {lang} wordlist ({len(words):,} words total so far).")
+        except Exception as e:
+            print(f"Warning: could not load glotlid-wordlists[{lang}] ({e}) — skipping.")
+    return words
+
+
+def load_spellchecker_words(languages: list[str]) -> set[str]:
+    """Load full vocabulary from pyspellchecker for the given GlotLID language codes.
+
+    pyspellchecker ships with comprehensive word-frequency dictionaries (~100k+ words),
+    unlike the GlotLID discriminative lists (~14–25k n-grams).  This catches common
+    words like 'comment', 'game', 'pesée' that GlotLID lists omit.
+    """
+    try:
+        from spellchecker import SpellChecker
+    except ImportError:
+        print("Warning: 'pyspellchecker' not installed — falling back to GlotLID wordlists only.")
+        return set()
+
+    words: set[str] = set()
+    for lang in languages:
+        sc_lang = _SPELLCHECKER_LANG_MAP.get(lang)
+        if sc_lang is None:
+            continue
+        try:
+            sc = SpellChecker(language=sc_lang)
+            words.update(sc.word_frequency.keys())
+            print(f"  Loaded spellchecker[{sc_lang}] ({len(words):,} words total so far).")
+        except Exception as e:
+            print(f"Warning: could not load spellchecker[{sc_lang}] ({e}) — skipping.")
+    return words
+
+
+def build_foreign_wordlist(
+    foreign_langs: list[str] | None = None,
+    moore_langs: list[str] | None = None,
+) -> set[str]:
+    """Build a foreign-word exclusion set for quality-warning checks.
+
+    Combines GlotLID word lists and pyspellchecker dictionaries for the given
+    *foreign_langs*, then removes any words that also appear in *moore_langs*
+    (so genuine Mooré loanwords are not flagged).
+
+    Args:
+        foreign_langs: GlotLID language codes to treat as foreign
+                       (default: ``["fra_Latn", "eng_Latn"]``).
+        moore_langs:   GlotLID language codes for the target language used to
+                       subtract overlap (default: ``["mos_Latn"]``).
+
+    Returns:
+        A ``set[str]`` of lowercase foreign words, with Mooré overlap removed.
+    """
+    if foreign_langs is None:
+        foreign_langs = ["fra_Latn", "eng_Latn"]
+    if moore_langs is None:
+        moore_langs = ["mos_Latn"]
+
+    glotlid_foreign = load_glotlid_wordlists(foreign_langs)
+    spell_foreign = load_spellchecker_words(foreign_langs)
+    raw_foreign = glotlid_foreign | spell_foreign
+    moore_wordlist = load_glotlid_wordlists(moore_langs)
+    foreign = raw_foreign - moore_wordlist
+    print(
+        f"  Exclusive foreign wordlist: {len(foreign):,} words "
+        f"({len(raw_foreign) - len(foreign):,} removed as Mooré overlap)."
+    )
+    return foreign

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1,0 +1,431 @@
+"""Tests for moore_web.annotate — IO helpers and annotation functions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from datasets import Dataset
+
+from moore_web.annotate import (
+    _hf_repo,
+    _is_hf,
+    annotate,
+    load_data,
+    run_comet_qe,
+    run_lang_id,
+    run_laser,
+    run_quality_warnings,
+    save_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_ROWS = [
+    {"french": "Bonjour tout le monde", "moore": "Yibeogo ne paam"},
+    {"french": "La santé est importante", "moore": "Laafɩ yaa sõama"},
+]
+
+
+@pytest.fixture()
+def small_dataset() -> Dataset:
+    return Dataset.from_list(_ROWS)
+
+
+@pytest.fixture()
+def jsonl_file(tmp_path: Path) -> Path:
+    p = tmp_path / "data.jsonl"
+    p.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in _ROWS), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# HF URI helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHfHelpers:
+    def test_is_hf_true(self):
+        assert _is_hf("hf://owner/repo") is True
+
+    def test_is_hf_false_local(self):
+        assert _is_hf("/path/to/file.jsonl") is False
+
+    def test_is_hf_false_relative(self):
+        assert _is_hf("data.jsonl") is False
+
+    def test_hf_repo_strips_prefix(self):
+        assert _hf_repo("hf://owner/repo") == "owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# load_data
+# ---------------------------------------------------------------------------
+
+
+class TestLoadData:
+    def test_local_jsonl_row_count(self, jsonl_file: Path):
+        ds = load_data(str(jsonl_file))
+        assert len(ds) == 2
+
+    def test_local_jsonl_columns(self, jsonl_file: Path):
+        ds = load_data(str(jsonl_file))
+        assert "french" in ds.column_names
+        assert "moore" in ds.column_names
+
+    def test_local_jsonl_values(self, jsonl_file: Path):
+        ds = load_data(str(jsonl_file))
+        assert ds["french"][0] == _ROWS[0]["french"]
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_data(str(tmp_path / "nonexistent.jsonl"))
+
+    def test_hf_uri_dispatches_to_hub(self):
+        """Verify hf:// URIs reach load_dataset — the DatasetNotFoundError proves it."""
+        from datasets.exceptions import DatasetNotFoundError
+
+        with pytest.raises(DatasetNotFoundError):
+            load_data("hf://this-owner-does-not-exist/this-repo-does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# save_data
+# ---------------------------------------------------------------------------
+
+
+class TestSaveData:
+    def test_local_jsonl_creates_file(self, small_dataset: Dataset, tmp_path: Path):
+        out = tmp_path / "out.jsonl"
+        save_data(small_dataset, str(out))
+        assert out.exists()
+
+    def test_local_jsonl_row_count(self, small_dataset: Dataset, tmp_path: Path):
+        out = tmp_path / "out.jsonl"
+        save_data(small_dataset, str(out))
+        rows = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert len(rows) == 2
+
+    def test_local_jsonl_content(self, small_dataset: Dataset, tmp_path: Path):
+        out = tmp_path / "out.jsonl"
+        save_data(small_dataset, str(out))
+        rows = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert rows[0]["french"] == _ROWS[0]["french"]
+
+    def test_local_creates_parent_dirs(self, small_dataset: Dataset, tmp_path: Path):
+        out = tmp_path / "nested" / "dir" / "out.jsonl"
+        save_data(small_dataset, str(out))
+        assert out.exists()
+
+    def test_hf_uri_calls_push_to_hub(self, small_dataset: Dataset, monkeypatch):
+        pushed: dict = {}
+
+        class MockDatasetDict(dict):
+            def push_to_hub(self, repo, private=False):
+                pushed["repo"] = repo
+                pushed["private"] = private
+
+        monkeypatch.setattr("moore_web.annotate.DatasetDict", MockDatasetDict)
+        save_data(small_dataset, "hf://owner/repo", private=True, split="train")
+        assert pushed["repo"] == "owner/repo"
+        assert pushed["private"] is True
+
+
+# ---------------------------------------------------------------------------
+# run_quality_warnings
+# ---------------------------------------------------------------------------
+
+
+class TestRunQualityWarnings:
+    def test_adds_quality_warnings_column(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        assert "quality_warnings" in result.column_names
+
+    def test_adds_identification_consistency_column(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        assert "identification_consistency" in result.column_names
+
+    def test_adds_len_ratio_column(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        assert "len_ratio" in result.column_names
+
+    def test_preserves_original_columns(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        assert "french" in result.column_names
+        assert "moore" in result.column_names
+
+    def test_quality_warnings_is_list_of_strings(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        for warnings in result["quality_warnings"]:
+            assert isinstance(warnings, list)
+            assert all(isinstance(w, str) for w in warnings)
+
+    def test_identification_consistency_in_range(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        for score in result["identification_consistency"]:
+            assert 0.0 <= score <= 1.0
+
+    def test_len_ratio_in_range(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        for ratio in result["len_ratio"]:
+            assert 0.0 <= ratio <= 1.0
+
+    def test_len_ratio_symmetric(self):
+        ds = Dataset.from_list(
+            [
+                {"french": "ab", "moore": "abcd"},
+                {"french": "abcd", "moore": "ab"},
+            ]
+        )
+        result = run_quality_warnings(ds, load_wordlists=False)
+        assert result["len_ratio"][0] == result["len_ratio"][1]
+        assert result["len_ratio"][0] == pytest.approx(0.5)
+
+    def test_custom_field_names(self):
+        ds = Dataset.from_list([{"src": "Bonjour", "tgt": "Yibeogo"}])
+        result = run_quality_warnings(ds, src_field="src", tgt_field="tgt", load_wordlists=False)
+        assert "quality_warnings" in result.column_names
+        # Injected mapping columns must not leak into output
+        assert "eng_Latn" not in result.column_names
+        assert "mos_Latn" not in result.column_names
+
+    def test_no_injected_columns_when_using_default_fields(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        assert "eng_Latn" not in result.column_names
+        assert "mos_Latn" not in result.column_names
+
+    def test_emoji_detected_in_target(self):
+        ds = Dataset.from_list([{"french": "Hello", "moore": "Hi 😀"}])
+        result = run_quality_warnings(ds, load_wordlists=False)
+        assert "emoji" in result["quality_warnings"][0]
+
+    def test_row_count_unchanged(self, small_dataset: Dataset):
+        result = run_quality_warnings(small_dataset, load_wordlists=False)
+        assert len(result) == len(small_dataset)
+
+
+# ---------------------------------------------------------------------------
+# run_lang_id
+# ---------------------------------------------------------------------------
+
+
+class TestRunLangId:
+    def _mock_annotate(self, dataset, model, source_col, target_col, batch_size):
+        n = len(dataset)
+        return (
+            dataset.add_column("source_glotlid_lang", ["fra_Latn"] * n)
+            .add_column("source_glotlid_prob", [0.99] * n)
+            .add_column("target_glotlid_lang", ["mos_Latn"] * n)
+            .add_column("target_glotlid_prob", [0.95] * n)
+        )
+
+    def test_adds_glotlid_columns(self, small_dataset: Dataset, monkeypatch):
+        import moore_web.glotlid as glotlid_mod
+
+        monkeypatch.setattr(glotlid_mod, "load_model", lambda: object())
+        monkeypatch.setattr(glotlid_mod, "annotate_dataset", self._mock_annotate)
+        result = run_lang_id(small_dataset)
+        for col in (
+            "source_glotlid_lang",
+            "source_glotlid_prob",
+            "target_glotlid_lang",
+            "target_glotlid_prob",
+        ):
+            assert col in result.column_names
+
+    def test_passes_field_names_to_annotate_dataset(self, small_dataset: Dataset, monkeypatch):
+        import moore_web.glotlid as glotlid_mod
+
+        called_with: dict = {}
+
+        def capturing_annotate(dataset, model, source_col, target_col, batch_size):
+            called_with["source_col"] = source_col
+            called_with["target_col"] = target_col
+            return self._mock_annotate(dataset, model, source_col, target_col, batch_size)
+
+        monkeypatch.setattr(glotlid_mod, "load_model", lambda: object())
+        monkeypatch.setattr(glotlid_mod, "annotate_dataset", capturing_annotate)
+        run_lang_id(small_dataset, src_field="french", tgt_field="moore")
+        assert called_with["source_col"] == "french"
+        assert called_with["target_col"] == "moore"
+
+    def test_accepts_pre_loaded_model(self, small_dataset: Dataset, monkeypatch):
+        import moore_web.glotlid as glotlid_mod
+
+        sentinel = object()
+        received: list = []
+
+        def capturing_annotate(dataset, model, source_col, target_col, batch_size):
+            received.append(model)
+            return self._mock_annotate(dataset, model, source_col, target_col, batch_size)
+
+        monkeypatch.setattr(glotlid_mod, "annotate_dataset", capturing_annotate)
+        run_lang_id(small_dataset, model=sentinel)
+        assert received[0] is sentinel
+
+
+# ---------------------------------------------------------------------------
+# run_laser
+# ---------------------------------------------------------------------------
+
+
+class TestRunLaser:
+    def _make_mock_encoder(self, embed_dim: int = 4):
+        class _MockEncoder:
+            def __init__(self, lang: str):
+                self.lang = lang
+
+            def encode_sentences(self, texts, normalize_embeddings=True):
+                n = len(texts)
+                # Return unit vectors so dot-product == 1.0
+                vecs = np.ones((n, embed_dim), dtype=np.float32)
+                norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+                return vecs / norms
+
+        return _MockEncoder
+
+    def test_default_column_name(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr("laser_encoders.LaserEncoderPipeline", self._make_mock_encoder())
+        result = run_laser(small_dataset)
+        assert "laser_fra_mos" in result.column_names
+
+    def test_custom_output_field(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr("laser_encoders.LaserEncoderPipeline", self._make_mock_encoder())
+        result = run_laser(small_dataset, output_field="my_laser")
+        assert "my_laser" in result.column_names
+
+    def test_laser_score_count_matches_rows(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr("laser_encoders.LaserEncoderPipeline", self._make_mock_encoder())
+        result = run_laser(small_dataset)
+        assert len(result["laser_fra_mos"]) == len(small_dataset)
+
+    def test_laser_score_range(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr("laser_encoders.LaserEncoderPipeline", self._make_mock_encoder())
+        result = run_laser(small_dataset)
+        for score in result["laser_fra_mos"]:
+            assert -1.0 <= score <= 1.0
+
+    def test_unit_vectors_give_score_one(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr("laser_encoders.LaserEncoderPipeline", self._make_mock_encoder())
+        result = run_laser(small_dataset)
+        for score in result["laser_fra_mos"]:
+            assert score == pytest.approx(1.0, abs=1e-3)
+
+    def test_preserves_original_columns(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr("laser_encoders.LaserEncoderPipeline", self._make_mock_encoder())
+        result = run_laser(small_dataset)
+        assert "french" in result.column_names
+        assert "moore" in result.column_names
+
+
+# ---------------------------------------------------------------------------
+# run_comet_qe
+# ---------------------------------------------------------------------------
+
+
+class TestRunCometQe:
+    def _make_mock_model(self, scores: list[float]):
+        mock_output = MagicMock()
+        mock_output.scores = scores
+        mock_model = MagicMock()
+        mock_model.predict.return_value = mock_output
+        return mock_model
+
+    def test_default_column_name(self, small_dataset: Dataset):
+        model = self._make_mock_model([0.85, 0.73])
+        result = run_comet_qe(small_dataset, model=model)
+        assert "comet_qe_french_moore" in result.column_names
+
+    def test_custom_output_field(self, small_dataset: Dataset):
+        model = self._make_mock_model([0.85, 0.73])
+        result = run_comet_qe(small_dataset, output_field="my_score", model=model)
+        assert "my_score" in result.column_names
+
+    def test_comet_qe_values(self, small_dataset: Dataset):
+        model = self._make_mock_model([0.85, 0.73])
+        result = run_comet_qe(small_dataset, model=model)
+        col = "comet_qe_french_moore"
+        assert result[col][0] == pytest.approx(0.85)
+        assert result[col][1] == pytest.approx(0.73)
+
+    def test_comet_qe_row_count(self, small_dataset: Dataset):
+        model = self._make_mock_model([0.85, 0.73])
+        result = run_comet_qe(small_dataset, model=model)
+        assert len(result["comet_qe_french_moore"]) == len(small_dataset)
+
+    def test_passes_correct_fields_to_model(self, small_dataset: Dataset):
+        model = self._make_mock_model([0.0, 0.0])
+        run_comet_qe(small_dataset, src_field="french", tgt_field="moore", model=model)
+        call_args = model.predict.call_args
+        data = call_args[0][0]
+        assert data[0]["src"] == _ROWS[0]["french"]
+        assert data[0]["mt"] == _ROWS[0]["moore"]
+
+    def test_preserves_original_columns(self, small_dataset: Dataset):
+        model = self._make_mock_model([0.85, 0.73])
+        result = run_comet_qe(small_dataset, model=model)
+        assert "french" in result.column_names
+        assert "moore" in result.column_names
+
+
+# ---------------------------------------------------------------------------
+# annotate (composer)
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotate:
+    def test_no_flags_returns_same_columns(self, small_dataset: Dataset):
+        result = annotate(small_dataset)
+        assert set(result.column_names) == set(small_dataset.column_names)
+
+    def test_quality_warn_adds_column(self, small_dataset: Dataset):
+        result = annotate(small_dataset, quality_warn=True, load_wordlists=False)
+        assert "quality_warnings" in result.column_names
+
+    def test_consistency_adds_column(self, small_dataset: Dataset):
+        result = annotate(small_dataset, consistency=True, load_wordlists=False)
+        assert "identification_consistency" in result.column_names
+
+    def test_quality_warn_and_consistency_single_pass(self, small_dataset: Dataset, monkeypatch):
+        """Both flags should trigger run_quality_warnings exactly once."""
+        call_count: list[int] = [0]
+        original = run_quality_warnings
+
+        def counting_wrapper(*args, **kwargs):
+            call_count[0] += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr("moore_web.annotate.run_quality_warnings", counting_wrapper)
+        annotate(small_dataset, quality_warn=True, consistency=True, load_wordlists=False)
+        assert call_count[0] == 1
+
+    def test_laser_flag(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr(
+            "moore_web.annotate.run_laser",
+            lambda ds, **kw: ds.add_column("laser_fra_mos", [0.9] * len(ds)),
+        )
+        result = annotate(small_dataset, laser=True)
+        assert "laser_fra_mos" in result.column_names
+
+    def test_comet_qe_flag(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr(
+            "moore_web.annotate.run_comet_qe",
+            lambda ds, **kw: ds.add_column("comet_qe_french_moore", [0.8] * len(ds)),
+        )
+        result = annotate(small_dataset, comet_qe=True)
+        assert "comet_qe_french_moore" in result.column_names
+
+    def test_multiple_flags_stack(self, small_dataset: Dataset, monkeypatch):
+        monkeypatch.setattr(
+            "moore_web.annotate.run_laser",
+            lambda ds, **kw: ds.add_column("laser_fra_mos", [0.9] * len(ds)),
+        )
+        result = annotate(small_dataset, quality_warn=True, laser=True, load_wordlists=False)
+        assert "quality_warnings" in result.column_names
+        assert "laser_fra_mos" in result.column_names

--- a/tests/test_book_parser_facilitateur.py
+++ b/tests/test_book_parser_facilitateur.py
@@ -1,7 +1,6 @@
 """Tests for book_parser_facilitateur: NUMBERED_ITEM_RE, collect_numbered_items,
 and start_after / stop_before sentinels in split_and_parse_by_sections."""
 
-
 from moore_web.book_parser_facilitateur import (
     NUMBERED_ITEM_RE,
     collect_numbered_items,


### PR DESCRIPTION
## Summary
- Reverts the revert commit (`839508e`) that mistakenly undid the feat/annotate-module work
- Restores `annotate.py`, `score_laser.py`, `wordlists.py`, `tests/test_annotate.py`, and all related CLI/module changes

## Test plan
- [x] Verify `annotate.py` and related modules are back
- [x] Run tests to confirm nothing is broken