### PR TITLE
feat: lexicon cleaning, proverb stripping, and fr-mos dataset builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ moore-web --help
 | `align` | Align a sentence list using LASER + FastDTW |
 | `annotate` | Enrich an aligned dataset with quality signals |
 | `e2e` | Full pipeline: parse → flatten → align (with optional annotation) |
+| `clean-lexicon` | Clean a lexicon JSONL file (synonym splitting, proverb stripping) |
 
 ### Sources
 
@@ -95,6 +96,26 @@ moore-web flatten -s sida -i parsed.json -o parallel.json
 moore-web align parallel.json -o aligned.json --min-laser-score 0.6
 ```
 
+**Clean a lexicon JSONL file:**
+
+```bash
+# Split comma/semicolon synonym lists into one entry per FR/MOS pair
+moore-web clean-lexicon -i final_data_hf/lexicon_entries.jsonl --split-synonyms
+
+# Strip proverb annotations from french/english fields (in-place)
+moore-web clean-lexicon -i final_data_hf/lexicon.jsonl --strip-proverb-notes
+
+# Both at once
+moore-web clean-lexicon -i lexicon.jsonl --split-synonyms --strip-proverb-notes
+```
+
+The `--split-synonyms` flag is also available in `e2e --source simple` to apply
+synonym splitting during the pipeline:
+
+```bash
+moore-web e2e -s simple -i dict.pdf -o out.jsonl --split-synonyms --strip-proverb-notes
+```
+
 **Annotate an existing dataset:**
 
 ```bash
@@ -131,6 +152,55 @@ moore-web annotate -i data.jsonl -o out.jsonl --src my_col --tgt other_col --las
 | `--tgt-lang` | LASER language code for the target encoder (e.g. `mos`, `mos_Latn`). Inferred from `--tgt` for known fields. |
 
 Known fields resolved automatically: `french`/`fr`/`fra` → `fra`, `english`/`en`/`eng` → `eng`, `moore`/`mo`/`mos` → `mos`. Pass `--src-lang`/`--tgt-lang` explicitly for any other field.
+
+## Dataset builder
+
+`build_fr_mos_dataset.py` assembles a combined French–Mooré parallel corpus from
+the local moore-web files and the [`madoss/mafand-fr-mos`](https://huggingface.co/datasets/madoss/mafand-fr-mos) HuggingFace dataset.
+
+### Local sources
+
+| File | Source tag | Rows | Eval-eligible |
+| ---- | ---------- | ----: | ------------- |
+| `lexicon.jsonl` | `lexicon` | 4 249 | yes |
+| `lexicon_entries.jsonl` | `lexicon_entries` | 19 793 | no (dict entries) |
+| `conseils_ministres_aligned.jsonl` | `conseils` | 7 596 | yes |
+| `raamde_aligned.jsonl` | `news` | 3 915 | yes |
+| `sida_aligned.jsonl` | `sida` | 216 | yes |
+| `sida-facilitateur_aligned.jsonl` | `kade` | 674 | yes |
+
+Dev/test are built by stratified sampling over eval-eligible sources.
+`lexicon_entries` (raw dictionary entries) stays train-only by default.
+Duplicate `(french, moore)` pairs are removed globally across all files.
+
+### Output splits
+
+| Split | Local | mafand | Total |
+| ----- | ----: | -----: | ----: |
+| train | ~32 600 | 2 493 | ~35 100 |
+| dev | 500 | 1 492 | ~2 000 |
+| test | 500 | 1 574 | ~2 100 |
+
+Output schema: `french | moore | source`
+
+### Dataset builder usage
+
+```bash
+# Write train/dev/test JSONL to ./fr_mos_combined/
+python build_fr_mos_dataset.py
+
+# Local data only (no HuggingFace download)
+python build_fr_mos_dataset.py --no-mafand --output-dir out/
+
+# Larger eval sets
+python build_fr_mos_dataset.py --dev-size 1000 --test-size 1000
+
+# Push to HuggingFace Hub
+python build_fr_mos_dataset.py --push-to-hub owner/fr-mos-combined
+
+# Keep lexicon_entries in eval too
+python build_fr_mos_dataset.py --train-only-sources ""
+```
 
 ## TODO
 

--- a/build_fr_mos_dataset.py
+++ b/build_fr_mos_dataset.py
@@ -1,0 +1,377 @@
+"""Build a combined French–Mooré dataset.
+
+Sources
+-------
+Moore-web collection (local JSONL files under ``--data-dir``):
+
+  File                              Source tag      Rows   Eval-eligible
+  ────────────────────────────────  ──────────────  ─────  ─────────────
+  lexicon.jsonl                     lexicon         4 249  yes
+  lexicon_entries.jsonl             lexicon_entries 19793  no  (dict entries)
+  conseils_ministres_aligned.jsonl  conseils        7 596  yes
+  raamde_aligned.jsonl              news            3 915  yes
+  sida_aligned.jsonl                sida              216  yes
+  sida-facilitateur_aligned.jsonl   kade              674  yes
+
+mafand-fr-mos (``--mafand-repo``, default: ``madoss/mafand-fr-mos``):
+  The existing train / validation / test splits are used directly.
+
+Output splits
+-------------
+  train  =  local train portion  +  mafand train
+  dev    =  local dev portion    +  mafand validation
+  test   =  local test portion   +  mafand test
+
+The local dev/test are built by stratified sampling over eval-eligible
+sources (use ``--train-only-sources`` to customise which sources stay
+train-only).  Remaining local rows go to train.
+
+Output schema:  french | moore | source
+
+Usage
+-----
+    # Write JSONL files to ./fr_mos_combined/
+    python build_fr_mos_dataset.py --output-dir fr_mos_combined
+
+    # Custom split sizes
+    python build_fr_mos_dataset.py --output-dir fr_mos_combined \\
+        --dev-size 600 --test-size 600
+
+    # Also push to the Hub
+    python build_fr_mos_dataset.py --output-dir fr_mos_combined \\
+        --push-to-hub madoss/fr-mos-combined
+
+    # Skip the mafand download (local data only)
+    python build_fr_mos_dataset.py --output-dir fr_mos_combined \\
+        --no-mafand
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from collections import defaultdict
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Local file registry
+# ---------------------------------------------------------------------------
+
+# (filename, source_tag)  — order matters for reproducibility
+_LOCAL_FILES: list[tuple[str, str]] = [
+    ("lexicon.jsonl", "lexicon"),
+    ("lexicon_entries.jsonl", "lexicon_entries"),
+    ("conseils_ministres_aligned.jsonl", "conseils"),
+    ("raamde_aligned.jsonl", "news"),
+    ("sida_aligned.jsonl", "sida"),
+    ("sida-facilitateur_aligned.jsonl", "kade"),
+]
+
+# Sources excluded from dev/test by default (raw dictionary entries are
+# not representative sentence pairs).
+_DEFAULT_TRAIN_ONLY: tuple[str, ...] = ("lexicon_entries",)
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_jsonl(path: Path, source_override: str | None = None) -> list[dict]:
+    """Read a JSONL file, keeping only french/moore/source."""
+    rows = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            fr = obj.get("french", "").strip()
+            mo = obj.get("moore", "").strip()
+            if not fr or not mo:
+                continue
+            src = source_override if source_override is not None else obj.get("source", "unknown")
+            rows.append({"french": fr, "moore": mo, "source": src})
+    return rows
+
+
+def _write_jsonl(rows: list[dict], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(f"  wrote {len(rows):>6,} rows → {path}")
+
+
+def _print_source_breakdown(rows: list[dict], label: str) -> None:
+    counts: dict[str, int] = defaultdict(int)
+    for r in rows:
+        counts[r["source"]] += 1
+    parts = "  ".join(f"{s}={n:,}" for s, n in sorted(counts.items()))
+    print(f"  {label}: {len(rows):,} rows  [{parts}]")
+
+
+# ---------------------------------------------------------------------------
+# Stratified split
+# ---------------------------------------------------------------------------
+
+
+def _stratified_split(
+    rows: list[dict],
+    dev_size: int,
+    test_size: int,
+    seed: int,
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Split *rows* into (train, dev, test) stratified by source.
+
+    Each source contributes proportionally to dev and test.  Sources
+    with fewer than 3 rows are kept entirely in train.
+    """
+    rng = random.Random(seed)
+
+    by_source: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        by_source[r["source"]].append(r)
+
+    total = len(rows)
+    dev_frac = dev_size / total
+    test_frac = test_size / total
+
+    train: list[dict] = []
+    dev: list[dict] = []
+    test: list[dict] = []
+
+    for src, src_rows in sorted(by_source.items()):
+        rng.shuffle(src_rows)
+        n = len(src_rows)
+        if n < 3:
+            train.extend(src_rows)
+            continue
+        n_dev = max(1, round(n * dev_frac))
+        n_test = max(1, round(n * test_frac))
+        # Guard: never take more than half of a tiny source for eval
+        n_dev = min(n_dev, n // 3)
+        n_test = min(n_test, n // 3)
+        dev.extend(src_rows[:n_dev])
+        test.extend(src_rows[n_dev : n_dev + n_test])
+        train.extend(src_rows[n_dev + n_test :])
+
+    rng.shuffle(train)
+    rng.shuffle(dev)
+    rng.shuffle(test)
+    return train, dev, test
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build(
+    data_dir: Path,
+    mafand_repo: str | None,
+    output_dir: Path,
+    dev_size: int,
+    test_size: int,
+    train_only_sources: tuple[str, ...],
+    push_to_hub: str | None,
+    hub_private: bool,
+    seed: int,
+) -> None:
+    # ---- 1. Load local files ------------------------------------------------
+    print("Loading local moore-web files …")
+    local_all: list[dict] = []
+    for filename, source_tag in _LOCAL_FILES:
+        path = data_dir / filename
+        if not path.exists():
+            print(f"  [skip] {filename} not found")
+            continue
+        rows = _load_jsonl(path, source_override=source_tag)
+        print(f"  {filename}: {len(rows):,} rows")
+        local_all.extend(rows)
+
+    # ---- 2. Deduplicate on (french, moore) across all local files -----------
+    seen: set[tuple[str, str]] = set()
+    deduped: list[dict] = []
+    for r in local_all:
+        key = (r["french"], r["moore"])
+        if key not in seen:
+            seen.add(key)
+            deduped.append(r)
+    n_dropped = len(local_all) - len(deduped)
+    if n_dropped:
+        print(f"\n  dedup: dropped {n_dropped:,} duplicate (fr, mos) pairs "
+              f"→ {len(deduped):,} unique rows")
+    local_all = deduped
+
+    # Separate train-only rows (dictionary entries etc.)
+    train_only = [r for r in local_all if r["source"] in train_only_sources]
+    splittable = [r for r in local_all if r["source"] not in train_only_sources]
+
+    print(f"\nEval-eligible rows: {len(splittable):,}  "
+          f"(train-only: {len(train_only):,})")
+
+    # ---- 2. Stratified split of splittable rows ----------------------------
+    print(f"\nBuilding stratified split  dev={dev_size}  test={test_size}  seed={seed} …")
+    local_train, local_dev, local_test = _stratified_split(
+        splittable, dev_size, test_size, seed
+    )
+    local_train = train_only + local_train  # re-attach train-only rows
+
+    print("  Local split:")
+    _print_source_breakdown(local_train, "train")
+    _print_source_breakdown(local_dev,   "dev  ")
+    _print_source_breakdown(local_test,  "test ")
+
+    # ---- 3. mafand splits --------------------------------------------------
+    mafand_train: list[dict] = []
+    mafand_dev: list[dict] = []
+    mafand_test: list[dict] = []
+
+    if mafand_repo:
+        print(f"\nLoading {mafand_repo} …")
+        from datasets import load_dataset  # lazy import
+
+        ds = load_dataset(mafand_repo)
+        for split_name, target in [
+            ("train", mafand_train),
+            ("validation", mafand_dev),
+            ("test", mafand_test),
+        ]:
+            if split_name not in ds:
+                print(f"  [skip] split '{split_name}' not found in {mafand_repo}")
+                continue
+            for row in ds[split_name]:
+                fr = (row.get("french") or "").strip()
+                mo = (row.get("moore") or "").strip()
+                src = row.get("source") or "mafand"
+                if fr and mo:
+                    target.append({"french": fr, "moore": mo, "source": src})
+            print(f"  {split_name}: {len(target):,} rows")
+
+    # ---- 4. Merge ----------------------------------------------------------
+    final_train = local_train + mafand_train
+    final_dev = local_dev + mafand_dev
+    final_test = local_test + mafand_test
+
+    random.Random(seed).shuffle(final_train)
+
+    print("\nFinal dataset:")
+    _print_source_breakdown(final_train, "train")
+    _print_source_breakdown(final_dev,   "dev  ")
+    _print_source_breakdown(final_test,  "test ")
+    total = len(final_train) + len(final_dev) + len(final_test)
+    print(f"  total: {total:,}")
+
+    # ---- 5. Write JSONL ----------------------------------------------------
+    if output_dir:
+        print(f"\nWriting to {output_dir}/ …")
+        _write_jsonl(final_train, output_dir / "train.jsonl")
+        _write_jsonl(final_dev,   output_dir / "dev.jsonl")
+        _write_jsonl(final_test,  output_dir / "test.jsonl")
+
+    # ---- 6. Push to Hub ----------------------------------------------------
+    if push_to_hub:
+        from datasets import Dataset, DatasetDict
+
+        print(f"\nPushing to {push_to_hub} …")
+        dataset_dict = DatasetDict({
+            "train":      Dataset.from_list(final_train),
+            "validation": Dataset.from_list(final_dev),
+            "test":       Dataset.from_list(final_test),
+        })
+        dataset_dict.push_to_hub(push_to_hub, private=hub_private)
+        print(f"Done. https://huggingface.co/datasets/{push_to_hub}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a combined French–Mooré dataset.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--data-dir",
+        default="final_data_hf",
+        metavar="DIR",
+        help="Directory containing local moore-web JSONL files (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--mafand-repo",
+        default="madoss/mafand-fr-mos",
+        metavar="REPO_ID",
+        help="HF Hub repo for mafand splits (default: %(default)s). "
+             "Pass empty string or use --no-mafand to skip.",
+    )
+    parser.add_argument(
+        "--no-mafand",
+        action="store_true",
+        help="Skip loading the mafand dataset (local data only).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        "-o",
+        default="fr_mos_combined",
+        metavar="DIR",
+        help="Directory to write train/dev/test JSONL files (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--push-to-hub",
+        default=None,
+        metavar="REPO_ID",
+        help="HF Hub repo to push the final DatasetDict to.",
+    )
+    parser.add_argument(
+        "--hub-private",
+        action="store_true",
+        help="Make the pushed Hub dataset private.",
+    )
+    parser.add_argument(
+        "--dev-size",
+        type=int,
+        default=500,
+        help="Target number of local rows allocated to dev (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=int,
+        default=500,
+        help="Target number of local rows allocated to test (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--train-only-sources",
+        nargs="+",
+        default=list(_DEFAULT_TRAIN_ONLY),
+        metavar="SOURCE",
+        help="Source tags that must stay in train only "
+             "(default: %(default)s).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility (default: %(default)s).",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    build(
+        data_dir=Path(args.data_dir),
+        mafand_repo=None if args.no_mafand else args.mafand_repo,
+        output_dir=Path(args.output_dir) if args.output_dir else None,
+        dev_size=args.dev_size,
+        test_size=args.test_size,
+        train_only_sources=tuple(args.train_only_sources),
+        push_to_hub=args.push_to_hub,
+        hub_private=args.hub_private,
+        seed=args.seed,
+    )

--- a/src/moore_web/clean_lexicon.py
+++ b/src/moore_web/clean_lexicon.py
@@ -1,0 +1,189 @@
+"""Clean lexicon JSONL entries.
+
+Two optional transformations:
+
+split-synonyms
+    Entries whose ``french`` and ``english`` fields contain comma- or
+    semicolon-separated synonym lists (e.g. "quietly, peacefully, calm")
+    are exploded into one entry per synonym pair.  The ``moore`` field is
+    replicated unchanged across all resulting entries.
+
+    Rules
+    -----
+    * Moore must not contain a comma/semicolon — if it does a warning is
+      emitted and the entry is kept as-is (likely a parsing artefact).
+    * All tokens produced by splitting French must be ≤ 4 words and must
+      not contain sentence-ending punctuation (., !, ?).  Entries that
+      fail this heuristic are kept as-is.
+    * FR and EN token counts must match; mismatches are warned and kept.
+
+strip-proverb-notes
+    Parenthetical proverb explanations such as
+    ``(Proverbe: nous devons épargner…)`` and leading labels such as
+    ``Proverbe : …`` / ``Proverb: …`` are removed from ``french`` and
+    ``english``.  ``len_ratio`` is recalculated (character-based) when
+    present in the entry.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from itertools import zip_longest
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+_SPLIT_SEP = re.compile(r"\s*[,;]\s*")
+
+# Trailing annotation after a sentence-ending character:
+#   ". Proverb"  ". Proverbe"  ". Proverb: …"  "). Proverbe disant …"
+#   ".Proverbe:"  ") Proverbe:"  "› Proverb, meaning: …"  ". A proverb indicating: …"
+# The lookbehind covers  .  !  ?  ›  »  )  ]  — all chars that can close a sentence
+# or a parenthetical before the label.
+# "proverbs»" (e.g. "listen to proverbs»") is safe: \b fails between b and s.
+_PROVERB_TRAILING = re.compile(
+    r"(?<=[.!?›»)\]])\s*(?:[Aa]\s+)?[Pp]roverbe?\b.*",
+    re.UNICODE | re.DOTALL,
+)
+
+# Parenthetical containing any form of "proverb" (closed or unclosed at end of string):
+#   "(Proverbe: …)"  "(proverb, e.g. …"  "(Proverb : …"
+#   "(proverbs indicating: …)"  "(proverbes indiquant: …)"  "(proverbsaying that …)"
+# Using \w* instead of \b so plural and OCR-merged forms are caught too.
+_PROVERB_PAREN = re.compile(
+    r"\s*\([^)]*[Pp]roverb\w*[^)]*(?:\)|$)",
+    re.UNICODE | re.DOTALL,
+)
+
+# Leading label:  "Proverbe :" / "Proverb:" / "proverbe :" …
+_PROVERB_PREFIX_FR = re.compile(r"^\s*[Pp]roverbe\s*:?\s*", re.UNICODE)
+_PROVERB_PREFIX_EN = re.compile(r"^\s*[Pp]roverb\s*:?\s*", re.UNICODE)
+
+
+# ---------------------------------------------------------------------------
+# Synonym splitting
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_synonym_list(french: str, moore: str) -> bool:
+    """Heuristic: True when *french* is a comma/semicolon-separated word list."""
+    if not _SPLIT_SEP.search(french):
+        return False
+    tokens = [t for t in _SPLIT_SEP.split(french.strip()) if t]
+    return (
+        len(tokens) >= 2
+        and all(len(t.split()) <= 4 for t in tokens)
+        and not any(re.search(r"[.!?]", t) for t in tokens)
+        and len(moore.split()) <= 4
+    )
+
+
+def _split_entry(entry: dict) -> list[dict]:
+    """Explode a synonym-list entry into one entry per FR/EN pair."""
+    moore = entry.get("moore", "")
+    french = entry.get("french", "")
+    english = entry.get("english", "")
+
+    if _SPLIT_SEP.search(moore):
+        logger.warning(
+            "Moore field contains comma/semicolon — possible parsing issue, keeping as-is: %r",
+            moore,
+        )
+        return [entry]
+
+    fr_tokens = [t for t in _SPLIT_SEP.split(french.strip()) if t]
+    en_tokens = [t for t in _SPLIT_SEP.split(english.strip()) if t]
+
+    # Moore is the reference: FR and EN synonym counts need not match.
+    # Fill the shorter list with its last token so no synonyms are lost.
+    fr_fill = fr_tokens[-1] if fr_tokens else ""
+    en_fill = en_tokens[-1] if en_tokens else ""
+    return [
+        {**entry, "french": fr or fr_fill, "english": en or en_fill}
+        for fr, en in zip_longest(fr_tokens, en_tokens)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Proverb stripping
+# ---------------------------------------------------------------------------
+
+
+def _has_proverb_note(entry: dict) -> bool:
+    french = entry.get("french", "")
+    english = entry.get("english", "")
+    return bool(
+        _PROVERB_TRAILING.search(french)
+        or _PROVERB_PAREN.search(french)
+        or _PROVERB_PREFIX_FR.match(french)
+        or _PROVERB_TRAILING.search(english)
+        or _PROVERB_PAREN.search(english)
+        or _PROVERB_PREFIX_EN.match(english)
+    )
+
+
+def _strip_proverb(entry: dict) -> dict:
+    """Remove proverb labels and parenthetical explanations, recalculate len_ratio."""
+    french = entry.get("french", "")
+    english = entry.get("english", "")
+
+    # Trailing annotation takes priority (covers the vast majority of cases)
+    french = _PROVERB_TRAILING.sub("", french)
+    english = _PROVERB_TRAILING.sub("", english)
+
+    # Remaining parenthetical notes (e.g. unclosed "(Proverb: …" at end)
+    french = _PROVERB_PAREN.sub("", french)
+    english = _PROVERB_PAREN.sub("", english)
+
+    french = _PROVERB_PREFIX_FR.sub("", french).strip()
+    english = _PROVERB_PREFIX_EN.sub("", english).strip()
+
+    # Collapse duplicate punctuation left by removal (e.g. ".." → ".")
+    french = re.sub(r"\.{2,}", ".", french).strip()
+    english = re.sub(r"\.{2,}", ".", english).strip()
+
+    new_entry = {**entry, "french": french, "english": english}
+
+    if "len_ratio" in entry and french and entry.get("moore", ""):
+        a = len(french)
+        b = len(entry["moore"])
+        new_entry["len_ratio"] = round(min(a, b) / max(a, b), 4) if a and b else 0.0
+
+    return new_entry
+
+
+# ---------------------------------------------------------------------------
+# Main processing
+# ---------------------------------------------------------------------------
+
+
+def process(
+    entries: list[dict],
+    split_synonyms: bool = False,
+    strip_proverb_notes: bool = False,
+) -> tuple[list[dict], int, int]:
+    """Apply cleaning transformations to *entries*.
+
+    Returns ``(output, n_split, n_proverb)``.
+    """
+    n_split = 0
+    n_proverb = 0
+    output: list[dict] = []
+
+    for entry in entries:
+        if strip_proverb_notes and _has_proverb_note(entry):
+            entry = _strip_proverb(entry)
+            n_proverb += 1
+
+        if split_synonyms and _looks_like_synonym_list(entry.get("french", ""), entry.get("moore", "")):
+            expanded = _split_entry(entry)
+            n_split += len(expanded) - 1
+            output.extend(expanded)
+        else:
+            output.append(entry)
+
+    return output, n_split, n_proverb

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Callable, Optional
 
 import msgspec
 import typer
@@ -117,13 +117,14 @@ def _finalize_aligned(
     add_quality_warn: bool,
     add_laser_score: bool,
     add_comet_qe: bool,
+    postprocess: Callable[[list[dict]], list[dict]] | None = None,
 ) -> None:
     """Write aligned corpus, optionally annotating and/or pushing to HF Hub."""
     out_str = str(out)
     needs_annotation = any([add_lang_id, add_consistency, add_quality_warn, add_laser_score, add_comet_qe])
     is_hf = out_str.startswith("hf://")
 
-    if needs_annotation or is_hf:
+    if needs_annotation or is_hf or postprocess:
         from datasets import Dataset
 
         from moore_web import annotate as _ann
@@ -135,6 +136,10 @@ def _finalize_aligned(
         if aligned.english:
             for row, en in zip(rows, aligned.english):
                 row["english"] = en
+
+        if postprocess:
+            rows = postprocess(rows)
+
         dataset = Dataset.from_list(rows)
 
         if needs_annotation:
@@ -606,7 +611,9 @@ def align(
     ] = None,
     min_score: Annotated[
         float,
-        typer.Option("--min-laser-score", min=0.0, max=1.0, help="Drop pairs below this LASER cosine similarity."),
+        typer.Option(
+            "--min-laser-score", min=0.0, max=1.0, help="Drop pairs below this LASER cosine similarity."
+        ),
     ] = 0.0,
     jsonl: Annotated[
         bool,
@@ -660,13 +667,19 @@ def annotate(
     ] = False,
     src_lang: Annotated[
         Optional[str],
-        typer.Option("--src-lang", help="LASER language code for the source encoder (e.g. fra, eng). "
-                     "Inferred from --src when known; required for unrecognized fields."),
+        typer.Option(
+            "--src-lang",
+            help="LASER language code for the source encoder (e.g. fra, eng). "
+            "Inferred from --src when known; required for unrecognized fields.",
+        ),
     ] = None,
     tgt_lang: Annotated[
         Optional[str],
-        typer.Option("--tgt-lang", help="LASER language code for the target encoder (e.g. mos). "
-                     "Inferred from --tgt when known; required for unrecognized fields."),
+        typer.Option(
+            "--tgt-lang",
+            help="LASER language code for the target encoder (e.g. mos). "
+            "Inferred from --tgt when known; required for unrecognized fields.",
+        ),
     ] = None,
     comet_qe: Annotated[
         bool, typer.Option("--comet-qe", is_flag=True, help="Add COMET-QE translation quality score.")
@@ -692,8 +705,10 @@ def annotate(
         lang_id = consistency = quality_warn = laser_score = comet_qe = True
 
     if not any([lang_id, consistency, quality_warn, laser_score, comet_qe]):
-        _err("No annotation flags specified. Pass at least one of: --lang-id, --consistency, "
-             "--quality-warn, --laser-score, --comet-qe.")
+        _err(
+            "No annotation flags specified. Pass at least one of: --lang-id, --consistency, "
+            "--quality-warn, --laser-score, --comet-qe."
+        )
         raise typer.Exit(1)
 
     dataset = _ann.load_data(input)
@@ -716,6 +731,85 @@ def annotate(
         dataset = dataset.remove_columns(["identification_consistency"])
 
     _ann.save_data(dataset, output, private=hf_private)
+
+
+# ---------------------------------------------------------------------------
+# clean-lexicon
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="clean-lexicon")
+def clean_lexicon(
+    input: Annotated[
+        Path,
+        typer.Option(
+            "--input",
+            "-i",
+            exists=True,
+            dir_okay=False,
+            help="Lexicon JSONL file to clean (modified in-place).",
+        ),
+    ],
+    split_synonyms: Annotated[
+        bool,
+        typer.Option(
+            "--split-synonyms",
+            is_flag=True,
+            help=(
+                "Explode comma/semicolon-separated synonym entries into one row per pair. "
+                "Warns when Moore contains a comma (parsing issue) or FR/EN counts mismatch."
+            ),
+        ),
+    ] = False,
+    strip_proverb_notes: Annotated[
+        bool,
+        typer.Option(
+            "--strip-proverb-notes",
+            is_flag=True,
+            help=(
+                "Remove parenthetical proverb explanations — e.g. '(Proverbe: …)' — "
+                "and leading labels such as 'Proverbe :' from french and english fields. "
+                "len_ratio is recalculated when present."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Clean a lexicon JSONL file in-place.
+
+    [bold]Split synonyms:[/bold]
+        moore-web clean-lexicon -i lexicon.jsonl --split-synonyms
+
+    [bold]Strip proverb notes:[/bold]
+        moore-web clean-lexicon -i lexicon.jsonl --strip-proverb-notes
+
+    [bold]Both:[/bold]
+        moore-web clean-lexicon -i lexicon.jsonl --split-synonyms --strip-proverb-notes
+    """
+    if not split_synonyms and not strip_proverb_notes:
+        _err("No flags specified. Pass --split-synonyms and/or --strip-proverb-notes.")
+        raise typer.Exit(1)
+
+    from moore_web.clean_lexicon import process as _clean
+
+    with open(input, encoding="utf-8") as fh:
+        entries = [json.loads(line) for line in fh if line.strip()]
+
+    output, n_split, n_proverb = _clean(
+        entries=entries,
+        split_synonyms=split_synonyms,
+        strip_proverb_notes=strip_proverb_notes,
+    )
+
+    with open(input, "w", encoding="utf-8") as fh:
+        for e in output:
+            fh.write(json.dumps(e, ensure_ascii=False) + "\n")
+
+    typer.echo(f"Input:  {len(entries)} entries")
+    if split_synonyms:
+        typer.echo(f"Split:  +{n_split} entries from synonym lists")
+    if strip_proverb_notes:
+        typer.echo(f"Stripped proverb notes: {n_proverb} entries")
+    typer.echo(f"Output: {len(output)} entries → {input}")
 
 
 # ---------------------------------------------------------------------------
@@ -759,7 +853,9 @@ def e2e(
     ] = True,
     min_score: Annotated[
         float,
-        typer.Option("--min-laser-score", min=0.0, max=1.0, help="Drop pairs below this LASER cosine similarity."),
+        typer.Option(
+            "--min-laser-score", min=0.0, max=1.0, help="Drop pairs below this LASER cosine similarity."
+        ),
     ] = 0.0,
     lang_id: Annotated[
         bool,
@@ -799,15 +895,21 @@ def e2e(
     ] = False,
     add_consistency: Annotated[
         bool,
-        typer.Option("--add-consistency", is_flag=True, help="Annotate aligned output with identification_consistency."),
+        typer.Option(
+            "--add-consistency", is_flag=True, help="Annotate aligned output with identification_consistency."
+        ),
     ] = False,
     add_quality_warn: Annotated[
         bool,
-        typer.Option("--add-quality-warn", is_flag=True, help="Annotate aligned output with quality_warnings."),
+        typer.Option(
+            "--add-quality-warn", is_flag=True, help="Annotate aligned output with quality_warnings."
+        ),
     ] = False,
     add_laser_score: Annotated[
         bool,
-        typer.Option("--add-laser-score", is_flag=True, help="Annotate aligned output with LASER similarity."),
+        typer.Option(
+            "--add-laser-score", is_flag=True, help="Annotate aligned output with LASER similarity."
+        ),
     ] = False,
     add_comet_qe: Annotated[
         bool,
@@ -821,6 +923,22 @@ def e2e(
         bool,
         typer.Option("--hf-private", is_flag=True, help="Push to HuggingFace as private dataset."),
     ] = False,
+    split_synonyms: Annotated[
+        bool,
+        typer.Option(
+            "--split-synonyms",
+            is_flag=True,
+            help="(simple only) Explode comma/semicolon-separated synonym entries into one row per pair.",
+        ),
+    ] = False,
+    strip_proverb_notes: Annotated[
+        bool,
+        typer.Option(
+            "--strip-proverb-notes",
+            is_flag=True,
+            help="(simple only) Strip parenthetical proverb explanations and leading 'Proverbe :' labels.",
+        ),
+    ] = False,
 ) -> None:
     """End-to-end pipeline: parse → flatten → align.
 
@@ -832,6 +950,33 @@ def e2e(
     """
     if do_annotate:
         add_lang_id = add_consistency = add_quality_warn = add_laser_score = add_comet_qe = True
+
+    if (split_synonyms or strip_proverb_notes) and source != Source.simple:
+        _err("--split-synonyms / --strip-proverb-notes are only supported for --source simple.")
+        raise typer.Exit(1)
+
+    if (split_synonyms or strip_proverb_notes) and output and str(output).startswith("hf://"):
+        _err("--split-synonyms / --strip-proverb-notes are not supported with HuggingFace output.")
+        raise typer.Exit(1)
+
+    _postprocess_entries: Callable[[list[dict]], list[dict]] | None = None
+    _postprocess_examples: Callable[[list[dict]], list[dict]] | None = None
+    if split_synonyms or strip_proverb_notes:
+        from moore_web.clean_lexicon import process as _clean
+
+        if split_synonyms:
+
+            def _postprocess_entries(rows: list[dict]) -> list[dict]:  # type: ignore[misc]
+                cleaned, n_split, _ = _clean(rows, split_synonyms=True, strip_proverb_notes=False)
+                typer.echo(f"      clean: +{n_split} entries from synonym splitting")
+                return cleaned
+
+        if strip_proverb_notes:
+
+            def _postprocess_examples(rows: list[dict]) -> list[dict]:  # type: ignore[misc]
+                cleaned, _, n_proverb = _clean(rows, split_synonyms=False, strip_proverb_notes=True)
+                typer.echo(f"      clean: {n_proverb} proverb notes stripped")
+                return cleaned
 
     _ann_kwargs: dict = dict(
         add_lang_id=add_lang_id,
@@ -946,7 +1091,7 @@ def e2e(
             pages = parse_doc(doc)
         typer.echo("[2/2] Flattening…")
 
-        def _write_simple(inc_examples: bool, inc_entries: bool, dest) -> None:
+        def _write_simple(inc_examples: bool, inc_entries: bool, dest, postprocess=None) -> None:
             p = flatten_simple_parser(pages, include_examples=inc_examples, include_entries=inc_entries)
             typer.echo(f"      FR: {len(p.french)}  MO: {len(p.moore)}  EN: {len(p.english)}  → {dest}")
             a = AlignedCorpus(
@@ -956,15 +1101,24 @@ def e2e(
                 scores=[1.0] * len(p.french),
                 source=p.source,
             )
-            _finalize_aligned(a, dest, jsonl, **_ann_kwargs)
+            _finalize_aligned(a, dest, jsonl, postprocess=postprocess, **_ann_kwargs)
 
         out = output or _default_output(input, f"_aligned{_ext}")
         if entries_output is not None:
             # Parse once, write examples and entries to separate files.
-            _write_simple(inc_examples=True, inc_entries=False, dest=out)
-            _write_simple(inc_examples=False, inc_entries=True, dest=entries_output)
+            _write_simple(inc_examples=True, inc_entries=False, dest=out, postprocess=_postprocess_examples)
+            _write_simple(
+                inc_examples=False, inc_entries=True, dest=entries_output, postprocess=_postprocess_entries
+            )
         else:
-            _write_simple(inc_examples=examples, inc_entries=entries, dest=out)
+            # Single output — pick the right hook based on what is being written
+            if entries and not examples:
+                _postprocess = _postprocess_entries
+            elif examples and not entries:
+                _postprocess = _postprocess_examples
+            else:
+                _postprocess = None  # mixed output, skip cleaning
+            _write_simple(inc_examples=examples, inc_entries=entries, dest=out, postprocess=_postprocess)
         return
 
     elif source == Source.conseils:


### PR DESCRIPTION
## Summary

- **`clean_lexicon.py`** — new module with two cleaning transformations for lexicon JSONL files:
  - `--split-synonyms`: explodes comma/semicolon synonym lists (e.g. `"quiétude, paisiblement"`) into one entry per FR/MOS pair using `zip_longest` (Moore is the reference language)
  - `--strip-proverb-notes`: removes proverb annotations from `french`/`english` fields — handles trailing `. Proverb…` / `. Proverbe…`, unclosed parentheticals `(Proverb: …`, plural forms `(proverbs indicating…)`, and OCR-merged forms `(proverbsaying that…)`
- **`cli.py`** — new `clean-lexicon` command for in-place JSONL cleaning; both flags also wired into `e2e --source simple` via per-file postprocess hooks (`--split-synonyms` → `lexicon_entries.jsonl`, `--strip-proverb-notes` → `lexicon.jsonl`)
- **`build_fr_mos_dataset.py`** — new script combining local moore-web JSONL files with `madoss/mafand-fr-mos`; builds stratified dev/test from local data, deduplicates on `(french, moore)` globally, outputs `train/dev/test` JSONL (~42k pairs total)
- **`README.md`** — updated with `clean-lexicon` command docs and a Dataset builder section

## Test plan

- [x] `moore-web clean-lexicon -i final_data_hf/lexicon_entries.jsonl --split-synonyms` — verify synonym entries are split
- [x] `moore-web clean-lexicon -i final_data_hf/lexicon.jsonl --strip-proverb-notes` — verify 40 proverb annotations stripped, `«read and listen to proverbs»` untouched
- [x] `python build_fr_mos_dataset.py --no-mafand` — verify 2 771 duplicates dropped, stratified split sums to 33 672
- [x] `python build_fr_mos_dataset.py` — verify mafand splits merged correctly (~42k total)