### PR TITLE
feat: quality filter in dataset builder and laser_score in explorer

### DIFF
--- a/build_fr_mos_dataset.py
+++ b/build_fr_mos_dataset.py
@@ -26,7 +26,7 @@ The local dev/test are built by stratified sampling over eval-eligible
 sources (use ``--train-only-sources`` to customise which sources stay
 train-only).  Remaining local rows go to train.
 
-Output schema:  french | moore | source
+Output schema:  french | moore | source | laser_score | comet_qe | len_ratio
 
 Usage
 -----
@@ -80,7 +80,7 @@ _DEFAULT_TRAIN_ONLY: tuple[str, ...] = ("lexicon_entries",)
 
 
 def _load_jsonl(path: Path, source_override: str | None = None) -> list[dict]:
-    """Read a JSONL file, keeping only french/moore/source."""
+    """Read a JSONL file, keeping french/moore/source/laser_score/comet_qe/len_ratio."""
     rows = []
     with path.open(encoding="utf-8") as fh:
         for line in fh:
@@ -93,7 +93,14 @@ def _load_jsonl(path: Path, source_override: str | None = None) -> list[dict]:
             if not fr or not mo:
                 continue
             src = source_override if source_override is not None else obj.get("source", "unknown")
-            rows.append({"french": fr, "moore": mo, "source": src})
+            rows.append({
+                "french": fr,
+                "moore": mo,
+                "source": src,
+                "laser_score": obj.get("laser_score"),
+                "comet_qe": obj.get("comet_qe"),
+                "len_ratio": obj.get("len_ratio"),
+            })
     return rows
 
 
@@ -111,6 +118,46 @@ def _print_source_breakdown(rows: list[dict], label: str) -> None:
         counts[r["source"]] += 1
     parts = "  ".join(f"{s}={n:,}" for s, n in sorted(counts.items()))
     print(f"  {label}: {len(rows):,} rows  [{parts}]")
+
+
+# ---------------------------------------------------------------------------
+# Quality filter
+# ---------------------------------------------------------------------------
+
+_FILTERS: dict[str, tuple[str, float]] = {
+    "len_ratio":   (">",  0.1),
+    "comet_qe":    (">=", 0.35),
+    "laser_score": (">=", 0.5),
+}
+
+
+def _passes_filter(row: dict) -> bool:
+    """Return True if the row passes all quality thresholds.
+
+    A threshold is skipped when the value is None (field absent for that source).
+    """
+    for field, (op, threshold) in _FILTERS.items():
+        val = row.get(field)
+        if val is None:
+            continue
+        if op == ">=" and val < threshold:
+            return False
+        if op == ">" and val <= threshold:
+            return False
+    return True
+
+
+def _apply_quality_filter(rows: list[dict]) -> list[dict]:
+    kept = [r for r in rows if _passes_filter(r)]
+    dropped = len(rows) - len(kept)
+    if dropped:
+        by_source: dict[str, int] = defaultdict(int)
+        for r in rows:
+            if not _passes_filter(r):
+                by_source[r["source"]] += 1
+        parts = "  ".join(f"{s}={n:,}" for s, n in sorted(by_source.items()))
+        print(f"  quality filter: dropped {dropped:,} rows  [{parts}]")
+    return kept
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +253,10 @@ def build(
               f"→ {len(deduped):,} unique rows")
     local_all = deduped
 
+    # ---- Quality filter -----------------------------------------------------
+    print("\nApplying quality filters …")
+    local_all = _apply_quality_filter(local_all)
+
     # Separate train-only rows (dictionary entries etc.)
     train_only = [r for r in local_all if r["source"] in train_only_sources]
     splittable = [r for r in local_all if r["source"] not in train_only_sources]
@@ -248,7 +299,14 @@ def build(
                 mo = (row.get("moore") or "").strip()
                 src = row.get("source") or "mafand"
                 if fr and mo:
-                    target.append({"french": fr, "moore": mo, "source": src})
+                    target.append({
+                        "french": fr,
+                        "moore": mo,
+                        "source": src,
+                        "laser_score": row.get("laser_score"),
+                        "comet_qe": row.get("comet_qe"),
+                        "len_ratio": row.get("len_ratio"),
+                    })
             print(f"  {split_name}: {len(target):,} rows")
 
     # ---- 4. Merge ----------------------------------------------------------
@@ -277,10 +335,13 @@ def build(
         from datasets import Dataset, DatasetDict
 
         print(f"\nPushing to {push_to_hub} …")
+        _drop_cols = {"quality_warnings"}
+        def _strip(rows: list[dict]) -> list[dict]:
+            return [{k: v for k, v in r.items() if k not in _drop_cols} for r in rows]
         dataset_dict = DatasetDict({
-            "train":      Dataset.from_list(final_train),
-            "validation": Dataset.from_list(final_dev),
-            "test":       Dataset.from_list(final_test),
+            "train":      Dataset.from_list(_strip(final_train)),
+            "validation": Dataset.from_list(_strip(final_dev)),
+            "test":       Dataset.from_list(_strip(final_test)),
         })
         dataset_dict.push_to_hub(push_to_hub, private=hub_private)
         print(f"Done. https://huggingface.co/datasets/{push_to_hub}")

--- a/notebooks/explore_aligned.py
+++ b/notebooks/explore_aligned.py
@@ -16,7 +16,7 @@ Run with:
 
 import marimo
 
-__generated_with = "0.22.4"
+__generated_with = "0.23.0"
 app = marimo.App(width="medium", app_title="Aligned Corpus Explorer")
 
 
@@ -35,7 +35,7 @@ def _():
 @app.cell
 def _(mo):
     file_path_input = mo.ui.text(
-        value="sida_aligned_with_qe.jsonl/sida_aligned.jsonl",
+        value="final_data_hf/conseils_ministres_aligned.jsonl",
         label="Aligned JSON path",
         placeholder="aligned.jsonl",
         full_width=True,
@@ -60,7 +60,7 @@ def _(Path, file_path_input, mo, pd):
 
 @app.cell
 def _(df, mo, source):
-    _sc = df["score"]
+    _sc = df["laser_score"]
     mo.hstack(
         [
             mo.stat(label="Pairs", value=str(len(df)), bordered=True),
@@ -77,7 +77,7 @@ def _(df, mo, source):
 
 @app.cell
 def _(df, mo):
-    _sc = df["score"]
+    _sc = df["laser_score"]
     threshold_slider = mo.ui.slider(
         start=float(_sc.min()),
         stop=float(_sc.max()),
@@ -94,7 +94,7 @@ def _(df, mo):
 @app.cell
 def _(df, mo, mticker, plt, threshold_slider):
     fig, ax = plt.subplots(figsize=(8, 3.5))
-    ax.hist(df["score"], bins=40, color="#4C72B0", edgecolor="white", linewidth=0.4)
+    ax.hist(df["laser_score"], bins=40, color="#4C72B0", edgecolor="white", linewidth=0.4)
     ax.axvline(
         threshold_slider.value,
         color="#DD4444",
@@ -114,12 +114,11 @@ def _(df, mo, mticker, plt, threshold_slider):
 
 @app.cell
 def _(df, mo, plt, threshold_slider):
-    _filtered = df[df["score"] >= threshold_slider.value]
+    _filtered = df[df["laser_score"] >= threshold_slider.value]
 
     fig2, ax2 = plt.subplots(figsize=(7, 4))
-    sc2 = ax2.scatter(
-        _filtered["fr_len"],
-        _filtered["mo_len"],
+    sc2 = ax2.lines(
+        _filtered["len_ratio"],
         c=_filtered["laser_score"],
         cmap="RdYlGn",
         alpha=0.55,
@@ -142,7 +141,7 @@ def _(df, mo, plt, threshold_slider):
 @app.cell
 def _(df, mo, pd):
     _pcts = [10, 25, 50, 75, 90, 95, 99]
-    _rows = [{"Percentile": f"p{p}", "Score": f"{df['score'].quantile(p / 100):.4f}"} for p in _pcts]
+    _rows = [{"Percentile": f"p{p}", "Score": f"{df['laser_score'].quantile(p / 100):.4f}"} for p in _pcts]
     mo.md("### Score percentiles"), mo.ui.table(pd.DataFrame(_rows), pagination=False, selection=None)
     return
 
@@ -180,10 +179,11 @@ def _(df, mo):
     _low = (
         df[df["laser_score"] < _cutoff]
         .sort_values("laser_score")
-        .reset_index(drop=True)[["laser_score", "french", "moore"]]
+        .reset_index(drop=True)[["laser_score", "french", "moore", "comet_qe"]]
         .copy()
     )
     _low["laser_score"] = _low["laser_score"].map("{:.4f}".format)
+    _low["comet_qe"] = _low["comet_qe"].map("{:.4f}".format)
 
     mo.vstack(
         [


### PR DESCRIPTION
## Summary

- Propagate `laser_score`, `comet_qe`, and `len_ratio` fields through the dataset builder pipeline
- Apply quality thresholds before train/dev/test splitting (drops low-quality rows by source)
- Rename `score` → `laser_score` in the Marimo explorer notebook, add `comet_qe` column to low-score table, bump marimo to 0.23.0

## Test plan

- [x] Run `python build_fr_mos_dataset.py` and verify quality filter logs dropped rows per source
- [x] Check output schema includes `laser_score`, `comet_qe`, `len_ratio`
- [x] Open `notebooks/explore_aligned.py` with marimo and confirm score histogram and scatter plot render correctly