### PR TITLE
feat: digital glossary parser and CLI source

### DIFF
--- a/build_fr_mos_dataset.py
+++ b/build_fr_mos_dataset.py
@@ -12,6 +12,8 @@ Moore-web collection (local JSONL files under ``--data-dir``):
   raamde_aligned.jsonl              news            3 915  yes
   sida_aligned.jsonl                sida              216  yes
   sida-facilitateur_aligned.jsonl   kade              674  yes
+  digital-terms.jsonl               digital-terms    ~300  no  (glossary terms)
+  digital-defs.jsonl                digital-defs     ~300  yes
 
 mafand-fr-mos (``--mafand-repo``, default: ``madoss/mafand-fr-mos``):
   The existing train / validation / test splits are used directly.
@@ -67,11 +69,13 @@ _LOCAL_FILES: list[tuple[str, str]] = [
     ("raamde_aligned.jsonl", "news"),
     ("sida_aligned.jsonl", "sida"),
     ("sida-facilitateur_aligned.jsonl", "kade"),
+    ("digital-terms.jsonl", "digital-terms"),
+    ("digital-defs.jsonl", "digital-defs"),
 ]
 
-# Sources excluded from dev/test by default (raw dictionary entries are
-# not representative sentence pairs).
-_DEFAULT_TRAIN_ONLY: tuple[str, ...] = ("lexicon_entries",)
+# Sources excluded from dev/test by default (raw dictionary entries or
+# short keyword pairs not representative of sentence-level translation).
+_DEFAULT_TRAIN_ONLY: tuple[str, ...] = ("lexicon_entries", "digital-terms")
 
 
 # ---------------------------------------------------------------------------

--- a/push_to_hf.py
+++ b/push_to_hf.py
@@ -10,6 +10,8 @@ One dataset, one config (subset) per source:
     load_dataset("MNIKIEMA/moore-fr-mo", name="sida")
     load_dataset("MNIKIEMA/moore-fr-mo", name="sida-facilitateur")
     load_dataset("MNIKIEMA/moore-fr-mo", name="lexicon")
+    load_dataset("MNIKIEMA/moore-fr-mo", name="digital-terms")   # glossary term pairs
+    load_dataset("MNIKIEMA/moore-fr-mo", name="digital-defs")    # glossary definition pairs
 
 Each record:
     {
@@ -49,6 +51,8 @@ SOURCES: dict[str, str] = {
     "sida-facilitateur": "final_data_hf/sida-facilitateur_aligned.jsonl",
     "lexicon": "final_data_hf/lexicon.jsonl",
     "lexicon-entries": "final_data_hf/lexicon_entries.jsonl",
+    "digital-terms": "final_data_hf/digital-terms.jsonl",
+    "digital-defs": "final_data_hf/digital-defs.jsonl",
 }
 
 # Sources that carry English translations

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -42,6 +42,7 @@ class Source(str, Enum):
     news = "news"
     simple = "simple"
     conseils = "conseils"
+    digital = "digital"
 
 
 class KadeLang(str, Enum):
@@ -878,6 +879,24 @@ def e2e(
             help="Write entries to a separate file (simple only). Avoids parsing the PDF twice.",
         ),
     ] = None,
+    terms: Annotated[
+        bool,
+        typer.Option("--terms/--no-terms", help="Include term pairs fr_term/mos_term (digital only)."),
+    ] = True,
+    definitions: Annotated[
+        bool,
+        typer.Option(
+            "--definitions/--no-definitions",
+            help="Include definition pairs fr_definition/mos_definition (digital only).",
+        ),
+    ] = False,
+    definitions_output: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--definitions-output",
+            help="Write definition pairs to a separate file (digital only). Avoids parsing the PDFs twice.",
+        ),
+    ] = None,
     drop_duplicate: Annotated[
         bool,
         typer.Option(
@@ -942,11 +961,13 @@ def e2e(
 ) -> None:
     """End-to-end pipeline: parse → flatten → align.
 
-    [bold]sida:[/bold]    moore-web e2e -s sida -i book.pdf -o aligned.json
-    [bold]kade:[/bold]    moore-web e2e -s kade --fr-input fr.pdf --mo-input mo.pdf -o aligned.json
-    [bold]news:[/bold]    moore-web e2e -s news -i corpus.json -o aligned.json
-    [bold]simple:[/bold]  moore-web e2e -s simple -i dict.pdf -o aligned.json
-    [bold]HF output:[/bold] moore-web e2e -s sida -i book.pdf -o hf://owner/repo --annotate
+    [bold]sida:[/bold]              moore-web e2e -s sida -i book.pdf -o aligned.json
+    [bold]kade:[/bold]              moore-web e2e -s kade --fr-input fr.pdf --mo-input mo.pdf -o aligned.json
+    [bold]news:[/bold]              moore-web e2e -s news -i corpus.json -o aligned.json
+    [bold]simple:[/bold]            moore-web e2e -s simple -i dict.pdf -o aligned.json
+    [bold]digital (terms):[/bold]   moore-web e2e -s digital --fr-input lexique.pdf --mo-input glossaire.pdf -o terms.jsonl --jsonl
+    [bold]digital (both):[/bold]    moore-web e2e -s digital --fr-input lexique.pdf --mo-input glossaire.pdf -o terms.jsonl --definitions-output defs.jsonl --jsonl --add-laser-score --add-comet-qe --add-quality-warn
+    [bold]HF output:[/bold]         moore-web e2e -s sida -i book.pdf -o hf://owner/repo --annotate
     """
     if do_annotate:
         add_lang_id = add_consistency = add_quality_warn = add_laser_score = add_comet_qe = True
@@ -957,6 +978,10 @@ def e2e(
 
     if (split_synonyms or strip_proverb_notes) and output and str(output).startswith("hf://"):
         _err("--split-synonyms / --strip-proverb-notes are not supported with HuggingFace output.")
+        raise typer.Exit(1)
+
+    if (terms is False or definitions or definitions_output is not None) and source != Source.digital:
+        _err("--terms / --definitions / --definitions-output are only supported for --source digital.")
         raise typer.Exit(1)
 
     _postprocess_entries: Callable[[list[dict]], list[dict]] | None = None
@@ -1169,6 +1194,59 @@ def e2e(
         if drop_duplicate:
             aligned = _dedup_aligned(aligned)
         _finalize_aligned(aligned, out, jsonl, **_ann_kwargs)
+        return
+
+    elif source == Source.digital:
+        if fr_input is None or mo_input is None:
+            _err("--fr-input (French lexique PDF) and --mo-input (Mooré glossaire PDF) are required for --source digital.")
+            raise typer.Exit(1)
+
+        from moore_web.flatten import AlignedCorpus
+        from moore_web.glossary_parser import (
+            align_glossaries,
+            extract_french_tables,
+            extract_moore_tables,
+        )
+
+        typer.echo("[1/2] Extracting glossary tables…")
+        moore_entries = extract_moore_tables(str(mo_input))
+        typer.echo(f"      Mooré entries : {len(moore_entries)}")
+        french_entries = extract_french_tables(str(fr_input))
+        typer.echo(f"      French entries: {len(french_entries)}")
+
+        typer.echo("[2/2] Aligning…")
+        pairs = align_glossaries(moore_entries, french_entries)
+        if moore_entries:
+            typer.echo(f"      Matched: {len(pairs)} / {len(moore_entries)} ({len(pairs)/len(moore_entries)*100:.1f}%)")
+
+        def _write_digital(inc_terms: bool, inc_definitions: bool, dest) -> None:
+            if inc_terms and not inc_definitions:
+                fr_texts = [p.fr_term for p in pairs]
+                mo_texts = [p.mos_term for p in pairs]
+                label = "digital-term"
+            elif inc_definitions and not inc_terms:
+                fr_texts = [p.fr_definition for p in pairs]
+                mo_texts = [p.mos_definition for p in pairs]
+                label = "digital-term-definition"
+            else:
+                fr_texts = [p.fr_term for p in pairs] + [p.fr_definition for p in pairs]
+                mo_texts = [p.mos_term for p in pairs] + [p.mos_definition for p in pairs]
+                label = "digital"
+            a = AlignedCorpus(
+                french=fr_texts,
+                moore=mo_texts,
+                scores=[1.0] * len(fr_texts),
+                source=label,
+            )
+            typer.echo(f"      FR: {len(fr_texts)}  MO: {len(mo_texts)}  → {dest}")
+            _finalize_aligned(a, dest, jsonl, **_ann_kwargs)
+
+        out = output or fr_input.with_name(f"digital_aligned{_ext}")
+        if definitions_output is not None:
+            _write_digital(inc_terms=True, inc_definitions=False, dest=out)
+            _write_digital(inc_terms=False, inc_definitions=True, dest=definitions_output)
+        else:
+            _write_digital(inc_terms=terms, inc_definitions=definitions, dest=out)
         return
 
     typer.echo(f"      FR: {len(parallel.french)} sentences  MO: {len(parallel.moore)} sentences")

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Callable, Optional
+from typing import Annotated, Callable, Optional, cast
 
 import msgspec
 import typer
@@ -1220,22 +1220,30 @@ def e2e(
             typer.echo(f"      Matched: {len(pairs)} / {len(moore_entries)} ({len(pairs)/len(moore_entries)*100:.1f}%)")
 
         def _write_digital(inc_terms: bool, inc_definitions: bool, dest) -> None:
+            _Scores = list[float | None]
+
             if inc_terms and not inc_definitions:
                 fr_texts = [p.fr_term for p in pairs]
                 mo_texts = [p.mos_term for p in pairs]
+                # Terms are aligned by exact key match → score 1.0 is appropriate.
+                scores = cast(_Scores, [1.0] * len(fr_texts))
                 label = "digital-term"
             elif inc_definitions and not inc_terms:
                 fr_texts = [p.fr_definition for p in pairs]
                 mo_texts = [p.mos_definition for p in pairs]
+                # Definitions are structurally paired (same glossary entry) but not
+                # alignment-scored; use None to signal the score is absent.
+                scores = cast(_Scores, [None] * len(fr_texts))
                 label = "digital-term-definition"
             else:
                 fr_texts = [p.fr_term for p in pairs] + [p.fr_definition for p in pairs]
                 mo_texts = [p.mos_term for p in pairs] + [p.mos_definition for p in pairs]
+                scores = cast(_Scores, [1.0] * len(pairs) + [None] * len(pairs))
                 label = "digital"
             a = AlignedCorpus(
                 french=fr_texts,
                 moore=mo_texts,
-                scores=[1.0] * len(fr_texts),
+                scores=scores,
                 source=label,
             )
             typer.echo(f"      FR: {len(fr_texts)}  MO: {len(mo_texts)}  → {dest}")

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -1228,22 +1228,26 @@ def e2e(
             _Scores = list[float | None]
 
             if inc_terms and not inc_definitions:
-                fr_texts = [p.fr_term for p in pairs]
-                mo_texts = [p.mos_term for p in pairs]
+                valid = [p for p in pairs if p.fr_term and p.mos_term]
+                fr_texts = [p.fr_term for p in valid]
+                mo_texts = [p.mos_term for p in valid]
                 # Terms are aligned by exact key match → score 1.0 is appropriate.
                 scores = cast(_Scores, [1.0] * len(fr_texts))
                 label = "digital-term"
             elif inc_definitions and not inc_terms:
-                fr_texts = [p.fr_definition for p in pairs]
-                mo_texts = [p.mos_definition for p in pairs]
+                valid = [p for p in pairs if p.fr_definition and p.mos_definition]
+                fr_texts = [p.fr_definition for p in valid]
+                mo_texts = [p.mos_definition for p in valid]
                 # Definitions are structurally paired (same glossary entry) but not
                 # alignment-scored; use None to signal the score is absent.
                 scores = cast(_Scores, [None] * len(fr_texts))
                 label = "digital-term-definition"
             else:
-                fr_texts = [p.fr_term for p in pairs] + [p.fr_definition for p in pairs]
-                mo_texts = [p.mos_term for p in pairs] + [p.mos_definition for p in pairs]
-                scores = cast(_Scores, [1.0] * len(pairs) + [None] * len(pairs))
+                term_pairs = [p for p in pairs if p.fr_term and p.mos_term]
+                def_pairs = [p for p in pairs if p.fr_definition and p.mos_definition]
+                fr_texts = [p.fr_term for p in term_pairs] + [p.fr_definition for p in def_pairs]
+                mo_texts = [p.mos_term for p in term_pairs] + [p.mos_definition for p in def_pairs]
+                scores = cast(_Scores, [1.0] * len(term_pairs) + [None] * len(def_pairs))
                 label = "digital"
             a = AlignedCorpus(
                 french=fr_texts,

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -141,6 +141,11 @@ def _finalize_aligned(
         if postprocess:
             rows = postprocess(rows)
 
+        # Drop laser_score entirely when every value is None (e.g. definition pairs).
+        if rows and all(r["laser_score"] is None for r in rows):
+            for r in rows:
+                del r["laser_score"]
+
         dataset = Dataset.from_list(rows)
 
         if needs_annotation:
@@ -1246,8 +1251,14 @@ def e2e(
                 scores=scores,
                 source=label,
             )
+            # Terms are exact key matches — LASER/COMET-QE add no information.
+            ann = _ann_kwargs if not (inc_terms and not inc_definitions) else {
+                **_ann_kwargs,
+                "add_laser_score": False,
+                "add_comet_qe": False,
+            }
             typer.echo(f"      FR: {len(fr_texts)}  MO: {len(mo_texts)}  → {dest}")
-            _finalize_aligned(a, dest, jsonl, **_ann_kwargs)
+            _finalize_aligned(a, dest, jsonl, **ann)
 
         out = output or fr_input.with_name(f"digital_aligned{_ext}")
         if definitions_output is not None:

--- a/src/moore_web/flatten.py
+++ b/src/moore_web/flatten.py
@@ -92,23 +92,23 @@ class AlignedCorpus(ParallelText):
     def to_jsonl_rows(self) -> list[dict]:
         """Return one dict per aligned pair, ready to write as JSONL."""
         has_english = bool(self.english)
+        omit_score = all(s is None for s in self.scores)
+
+        def _row(french: str, moore: str, score: float | None, english: str | None = None) -> dict:
+            r: dict = {"french": french, "moore": moore}
+            if english is not None:
+                r["english"] = english
+            if not omit_score:
+                r["laser_score"] = round(score, 4) if score is not None else None
+            r["source"] = self.source
+            return r
+
         if has_english:
             return [
-                {
-                    "french": french,
-                    "moore": moore,
-                    "english": english,
-                    "laser_score": round(score, 4),
-                    "source": self.source,
-                }
-                for i, (french, moore, english, score) in enumerate(
-                    zip(self.french, self.moore, self.english, self.scores)
-                )
+                _row(f, m, s, en)
+                for f, m, s, en in zip(self.french, self.moore, self.scores, self.english)
             ]
-        return [
-            {"french": french, "moore": moore, "laser_score": round(score, 4), "source": self.source}
-            for french, moore, score in zip(self.french, self.moore, self.scores)
-        ]
+        return [_row(f, m, s) for f, m, s in zip(self.french, self.moore, self.scores)]
 
     def write_jsonl(self, path: str) -> None:
         """Write aligned pairs to a JSONL file."""

--- a/src/moore_web/flatten.py
+++ b/src/moore_web/flatten.py
@@ -70,7 +70,7 @@ class AlignedCorpus(ParallelText):
     ``__post_init__`` enforces the length invariant.
     """
 
-    scores: list[float] = msgspec.field(default_factory=list)
+    scores: list[float | None] = msgspec.field(default_factory=list)
 
     def __post_init__(self) -> None:
         n_fr, n_mo, n_sc = len(self.french), len(self.moore), len(self.scores)

--- a/src/moore_web/glossary_parser.py
+++ b/src/moore_web/glossary_parser.py
@@ -1,0 +1,425 @@
+"""Parse glossary PDFs and produce aligned French/Mooré pairs.
+
+Sources
+-------
+- Mooré:  Glossaire_des_termes_usuels_du_numerique_et_de_la_poste_en_Moore__valide.pdf
+- French: Lexique_de_l_economie_numerique_et_des_postes.pdf
+
+Mooré PDF layout (47 pages)
+-----------------------------
+  Pages 1-3  : text (Mooré preface/introduction) → sentence segments
+  Page  4    : section header "Pipi palle Nimeriki" → skip
+  Pages 5-47 : glossary tables (4 cols: N°, TERMES, GOM-BI-TIGSI, B VÔOR WILGRI)
+               page 45 is a postal-section header → automatically skipped (no valid table)
+
+French PDF layout (94 pages)
+------------------------------
+  Pages 1-4  : text (French preface/introduction) → sentence segments
+  Page  5    : section header "Partie 1 Économie Numérique" → skip
+  Pages 6-86 : glossary tables (3 cols: N°, Mots clés, Définitions)
+  Pages 87-94: appendices / end matter → skip
+
+Alignment heuristic
+--------------------
+  Match TERMES (Mooré PDF, French term column) to Mots clés (French PDF) using
+  case-insensitive, accent-stripped key comparison.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from pathlib import Path
+
+import msgspec
+import pdfplumber
+
+from moore_web.pdf_extractor import extract_pdf_blocks
+from moore_web.segment import split_sentences
+
+
+# ---------------------------------------------------------------------------
+# pdfplumber table detection settings
+# ---------------------------------------------------------------------------
+
+_SETTINGS_STRICT = {
+    "vertical_strategy": "lines",
+    "horizontal_strategy": "lines",
+    "snap_tolerance": 3,
+    "join_tolerance": 3,
+    "edge_min_length": 50,  # filters out decorative borders
+    "min_words_vertical": 1,
+    "min_words_horizontal": 1,
+}
+
+# Fallback for pages where the section-letter box confuses strict detection
+_SETTINGS_LOOSE = {
+    "vertical_strategy": "lines",
+    "horizontal_strategy": "lines",
+    "snap_tolerance": 5,
+    "join_tolerance": 5,
+    "edge_min_length": 30,
+    "min_words_vertical": 1,
+    "min_words_horizontal": 1,
+}
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class MooreEntry(msgspec.Struct):
+    num: str
+    fr_term: str
+    mos_term: str
+    mos_definition: str
+    source: str = "moore_glossary"
+
+
+class FrenchEntry(msgspec.Struct):
+    num: str
+    fr_term: str
+    fr_definition: str
+    source: str = "french_lexique"
+
+
+class AlignedEntry(msgspec.Struct):
+    fr_term: str
+    mos_term: str
+    fr_definition: str
+    mos_definition: str
+    source: str = "glossary_aligned"
+
+
+class TextSegment(msgspec.Struct):
+    text: str
+    lang: str
+    source: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HEADER_KEYWORDS_MOORE = {"N°", "TERMES", "GOM", "TIGSI", "VÕOR", "WILGRI"}
+_HEADER_KEYWORDS_FRENCH = {"N°", "Mots", "clés", "Définitions"}
+
+# Typographic characters → plain ASCII equivalents
+_UNICODE_MAP = str.maketrans(
+    {
+        "\u2018": "'",   # '  LEFT SINGLE QUOTATION MARK
+        "\u2019": "'",   # '  RIGHT SINGLE QUOTATION MARK  ← reported
+        "\u201a": "'",   # ‚  SINGLE LOW-9 QUOTATION MARK
+        "\u201b": "'",   # ‛  SINGLE HIGH-REVERSED-9 QUOTATION MARK
+        "\u201c": '"',   # "  LEFT DOUBLE QUOTATION MARK
+        "\u201d": '"',   # "  RIGHT DOUBLE QUOTATION MARK
+        "\u201e": '"',   # „  DOUBLE LOW-9 QUOTATION MARK
+        "\u2013": "-",   # –  EN DASH
+        "\u2014": "-",   # —  EM DASH
+        "\u2015": "-",   # ―  HORIZONTAL BAR
+        "\u2026": "...", # …  HORIZONTAL ELLIPSIS
+        "\u00a0": " ",   # non-breaking space
+        "\u202f": " ",   # narrow no-break space
+        "\u2009": " ",   # thin space
+        "\u00ab": '"',   # «  LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+        "\u00bb": '"',   # »  RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    }
+)
+
+
+def normalize_unicode(text: str) -> str:
+    """Replace typographic punctuation with plain ASCII equivalents."""
+    return text.translate(_UNICODE_MAP)
+
+
+def _clean(value: str | None) -> str:
+    """Collapse whitespace, normalize typographic chars, and strip a cell value."""
+    if value is None:
+        return ""
+    return " ".join(normalize_unicode(value).split())
+
+
+def _normalize_key(text: str) -> str:
+    """Lowercase + strip diacritics for fuzzy term matching."""
+    nfkd = unicodedata.normalize("NFKD", text.lower().strip())
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
+def _is_header_row(row: list[str], keywords: set[str]) -> bool:
+    joined = " ".join(row)
+    return any(kw in joined for kw in keywords)
+
+
+def _best_table(page, min_cols: int) -> list[list[str]] | None:
+    """Return the best valid table from a page, trying strict then loose settings."""
+    for settings in (_SETTINGS_STRICT, _SETTINGS_LOOSE):
+        tables = page.extract_tables(settings)
+        candidates = [t for t in tables if t and len(t[0]) >= min_cols]
+        if candidates:
+            # prefer the table with the most data rows (not the decorative border)
+            best = max(candidates, key=lambda t: sum(1 for r in t if any(_clean(c) for c in r)))
+            cleaned = [[_clean(c) for c in row] for row in best]
+            return cleaned
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Mooré glossary extractor
+# ---------------------------------------------------------------------------
+
+MOORE_PDF = "Glossaire_des_termes_usuels_du_numerique_et_de_la_poste_en_Moore__valide.pdf"
+
+_MOORE_TEXT_PAGE_RANGE = (1, 3)   # 1-based inclusive
+_MOORE_SKIP_PAGES = {4}           # section header pages (1-based)
+
+
+def _parse_moore_row(row: list[str], ncols: int) -> MooreEntry | None:
+    """Map a row to MooreEntry regardless of whether TERMES column is present."""
+    if ncols == 4:
+        num, fr_term, mos_term, mos_def = row[0], row[1], row[2], row[3]
+    elif ncols == 3:
+        # TERMES column missing (e.g. page 24 K-section)
+        num, mos_term, mos_def = row[0], row[1], row[2]
+        fr_term = ""
+    else:
+        return None
+
+    if not mos_term and not fr_term:
+        return None
+
+    return MooreEntry(num=num, fr_term=fr_term, mos_term=mos_term, mos_definition=mos_def)
+
+
+def extract_moore_tables(pdf_path: str = MOORE_PDF) -> list[MooreEntry]:
+    entries: list[MooreEntry] = []
+
+    with pdfplumber.open(pdf_path) as pdf:
+        for idx, page in enumerate(pdf.pages):
+            page_num = idx + 1
+            if page_num <= _MOORE_TEXT_PAGE_RANGE[1] or page_num in _MOORE_SKIP_PAGES:
+                continue
+
+            rows = _best_table(page, min_cols=3)
+            if not rows:
+                continue
+
+            # skip header row(s)
+            start = 1 if _is_header_row(rows[0], _HEADER_KEYWORDS_MOORE) else 0
+            ncols = len(rows[0])
+
+            for row in rows[start:]:
+                entry = _parse_moore_row(row, ncols)
+                if entry:
+                    entries.append(entry)
+
+    return entries
+
+
+def extract_moore_text_segments(pdf_path: str = MOORE_PDF) -> list[TextSegment]:
+    text = normalize_unicode(extract_pdf_blocks(pdf_path, page_range=_MOORE_TEXT_PAGE_RANGE))
+    return [
+        TextSegment(text=sent, lang="mos", source="moore_glossary_preface")
+        for sent in split_sentences(text)
+        if sent.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# French lexique extractor
+# ---------------------------------------------------------------------------
+
+FRENCH_PDF = "Lexique_de_l_economie_numerique_et_des_postes.pdf"
+
+_FRENCH_TEXT_PAGE_RANGE = (1, 4)   # 1-based inclusive
+_FRENCH_SKIP_PAGES = {5}           # section header pages (1-based)
+_FRENCH_TABLE_LAST_PAGE = 86       # 1-based; pages 87-94 are appendices
+
+
+def extract_french_tables(pdf_path: str = FRENCH_PDF) -> list[FrenchEntry]:
+    entries: list[FrenchEntry] = []
+
+    with pdfplumber.open(pdf_path) as pdf:
+        for idx, page in enumerate(pdf.pages):
+            page_num = idx + 1
+            if page_num <= _FRENCH_TEXT_PAGE_RANGE[1] or page_num in _FRENCH_SKIP_PAGES:
+                continue
+            if page_num > _FRENCH_TABLE_LAST_PAGE:
+                break
+
+            rows = _best_table(page, min_cols=2)
+            if not rows:
+                continue
+
+            start = 1 if _is_header_row(rows[0], _HEADER_KEYWORDS_FRENCH) else 0
+
+            for row in rows[start:]:
+                if len(row) < 3:
+                    continue
+                num, fr_term, fr_def = row[0], row[1], row[2]
+                if not fr_term:
+                    continue
+                entries.append(FrenchEntry(num=num, fr_term=fr_term, fr_definition=fr_def))
+
+    return entries
+
+
+def extract_french_text_segments(pdf_path: str = FRENCH_PDF) -> list[TextSegment]:
+    text = normalize_unicode(extract_pdf_blocks(pdf_path, page_range=_FRENCH_TEXT_PAGE_RANGE))
+    return [
+        TextSegment(text=sent, lang="fr", source="french_lexique_preface")
+        for sent in split_sentences(text)
+        if sent.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Alignment
+# ---------------------------------------------------------------------------
+
+
+def align_glossaries(
+    moore_entries: list[MooreEntry],
+    french_entries: list[FrenchEntry],
+) -> list[AlignedEntry]:
+    """Match Mooré entries to French entries via a three-pass lookup.
+
+    Pass 1 — exact normalized match
+        Lowercase + strip diacritics on both sides.
+
+    Pass 2 — acronym-in-parentheses
+        Index French terms by their parenthesised substring.
+        e.g. "Asymetric Digital Subscriber Line (ADSL)" is also reachable by "adsl",
+        so a Mooré entry with fr_term="ADSL" gets matched.
+
+    Pass 3 — space-collapse (PDF line-break artefacts)
+        Some terms in the Mooré PDF have mid-word spaces introduced by the PDF
+        renderer at line boundaries (e.g. "Communicatio ns électroniques").
+        Collapsing all whitespace before comparing catches these.
+    """
+    # Pass 1 index: normalised term → entry
+    fr_exact: dict[str, FrenchEntry] = {
+        _normalize_key(fe.fr_term): fe for fe in french_entries
+    }
+
+    # Pass 2 index: normalised text-in-parens → entry
+    fr_paren: dict[str, FrenchEntry] = {}
+    for fe in french_entries:
+        m = re.search(r"\(([^)]+)\)", fe.fr_term)
+        if m:
+            fr_paren[_normalize_key(m.group(1))] = fe
+
+    # Pass 3 index: space-collapsed normalised term → entry
+    fr_nospace: dict[str, FrenchEntry] = {
+        re.sub(r"\s+", "", _normalize_key(fe.fr_term)): fe for fe in french_entries
+    }
+
+    aligned: list[AlignedEntry] = []
+    for me in moore_entries:
+        if not me.fr_term:
+            continue
+
+        key = _normalize_key(me.fr_term)
+        fe = (
+            fr_exact.get(key)
+            or fr_paren.get(key)
+            or fr_nospace.get(re.sub(r"\s+", "", key))
+        )
+        if fe:
+            aligned.append(
+                AlignedEntry(
+                    fr_term=fe.fr_term,
+                    mos_term=me.mos_term,
+                    fr_definition=fe.fr_definition,
+                    mos_definition=me.mos_definition,
+                )
+            )
+
+    return aligned
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(items: list, path: Path) -> None:
+    encoder = msgspec.json.Encoder()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        for item in items:
+            f.write(encoder.encode(item))
+            f.write(b"\n")
+    print(f"  wrote {len(items):>5} rows  →  {path}")
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_glossaries(
+    moore_pdf: str = MOORE_PDF,
+    french_pdf: str = FRENCH_PDF,
+    output_dir: str = "data/glossary",
+    skip_preface: bool = True,
+) -> None:
+    """Extract, align, and save glossary data.
+
+    Args:
+        moore_pdf:     Path to the Mooré glossary PDF.
+        french_pdf:    Path to the French lexique PDF.
+        output_dir:    Directory where JSONL files are written.
+        skip_preface:  When True (default), omit preface/introduction text
+                       segments — they are thematic prose unrelated to the
+                       glossary entries and not useful for alignment.
+    """
+    out = Path(output_dir)
+
+    print("Extracting Mooré glossary tables…")
+    moore_entries = extract_moore_tables(moore_pdf)
+    _write_jsonl(moore_entries, out / "moore_entries.jsonl")
+
+    print("Extracting French lexique tables…")
+    french_entries = extract_french_tables(french_pdf)
+    _write_jsonl(french_entries, out / "french_entries.jsonl")
+
+    print("Aligning glossaries…")
+    aligned = align_glossaries(moore_entries, french_entries)
+    _write_jsonl(aligned, out / "aligned.jsonl")
+    if moore_entries:
+        print(f"  matched {len(aligned)} / {len(moore_entries)} Mooré entries "
+              f"({len(aligned)/len(moore_entries)*100:.1f}%)")
+
+    if not skip_preface:
+        print("Extracting Mooré text segments (pages 1-3)…")
+        moore_text = extract_moore_text_segments(moore_pdf)
+        _write_jsonl(moore_text, out / "moore_text_segments.jsonl")
+
+        print("Extracting French text segments (pages 1-4)…")
+        french_text = extract_french_text_segments(french_pdf)
+        _write_jsonl(french_text, out / "french_text_segments.jsonl")
+    else:
+        print("  skipping preface/introduction segments (skip_preface=True)")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Parse glossary PDFs and produce aligned pairs.")
+    ap.add_argument("--moore-pdf", default=MOORE_PDF)
+    ap.add_argument("--french-pdf", default=FRENCH_PDF)
+    ap.add_argument("--output-dir", default="data/glossary")
+    ap.add_argument(
+        "--include-preface",
+        action="store_true",
+        help="Also extract preface/introduction text segments (skipped by default).",
+    )
+    args = ap.parse_args()
+
+    parse_glossaries(
+        moore_pdf=args.moore_pdf,
+        french_pdf=args.french_pdf,
+        output_dir=args.output_dir,
+        skip_preface=not args.include_preface,
+    )

--- a/src/moore_web/glossary_parser.py
+++ b/src/moore_web/glossary_parser.py
@@ -146,6 +146,21 @@ def _normalize_key(text: str) -> str:
     return "".join(c for c in nfkd if not unicodedata.combining(c))
 
 
+def _fix_moore_hyphens(text: str) -> str:
+    """Remove spurious spaces around hyphens in Mooré compound words.
+
+    PDF extraction inserts whitespace at cell line-breaks, splitting
+    compound words like ``tʋʋm-teed`` into ``tʋʋm- teed``.
+    Fix: collapse any whitespace immediately after (or before) a hyphen
+    that sits between two word characters.
+    """
+    # space(s) after hyphen:  "tʋʋm- teed"  → "tʋʋm-teed"
+    text = re.sub(r"(?<=\w)-\s+(?=\w)", "-", text)
+    # space(s) before hyphen: "tʋʋm -teed"  → "tʋʋm-teed"
+    text = re.sub(r"(?<=\w)\s+-(?=\w)", "-", text)
+    return text
+
+
 def _is_header_row(row: list[str], keywords: set[str]) -> bool:
     joined = " ".join(row)
     return any(kw in joined for kw in keywords)
@@ -188,7 +203,12 @@ def _parse_moore_row(row: list[str], ncols: int) -> MooreEntry | None:
     if not mos_term and not fr_term:
         return None
 
-    return MooreEntry(num=num, fr_term=fr_term, mos_term=mos_term, mos_definition=mos_def)
+    return MooreEntry(
+        num=num,
+        fr_term=fr_term,
+        mos_term=_fix_moore_hyphens(mos_term),
+        mos_definition=_fix_moore_hyphens(mos_def),
+    )
 
 
 def extract_moore_tables(pdf_path: str = MOORE_PDF) -> list[MooreEntry]:

--- a/test_pdfplumber.py
+++ b/test_pdfplumber.py
@@ -1,0 +1,75 @@
+import pdfplumber
+import pandas as pd
+import json
+
+PDF_PATH = "Glossaire_des_termes_usuels_du_numerique_et_de_la_poste_en_Moore__valide.pdf"
+
+# Tune line detection: ignore short decorative border lines, snap nearby edges
+TABLE_SETTINGS = {
+    "vertical_strategy": "lines",
+    "horizontal_strategy": "lines",
+    "snap_tolerance": 3,
+    "join_tolerance": 3,
+    "edge_min_length": 50,  # skip ornamental/border lines shorter than 50pt
+    "min_words_vertical": 1,
+    "min_words_horizontal": 1,
+}
+
+# Minimum columns a table must have to be considered a glossary table
+MIN_COLS = 3
+
+
+def clean_cell(value: str | None) -> str:
+    """Normalize whitespace in a cell value."""
+    if value is None:
+        return ""
+    return " ".join(value.split())
+
+
+def extract_glossary_tables(pdf_path: str, pages: list[int] | None = None) -> list[dict]:
+    results = []
+
+    with pdfplumber.open(pdf_path) as pdf:
+        target_pages = pages if pages else range(len(pdf.pages))
+
+        for page_num in target_pages:
+            page = pdf.pages[page_num]
+            tables = page.extract_tables(TABLE_SETTINGS)
+
+            glossary_tables = [t for t in tables if t and len(t[0]) >= MIN_COLS]
+
+            if not glossary_tables:
+                print(f"Page {page_num + 1}: no glossary tables found")
+                continue
+
+            for i, table in enumerate(glossary_tables):
+                header = [clean_cell(c) for c in table[0]]
+                rows = [[clean_cell(c) for c in row] for row in table[1:]]
+
+                print(f"\nPage {page_num + 1}, Table {i + 1} — {len(rows)} entries x {len(header)} cols")
+                df = pd.DataFrame(rows, columns=header)
+                print(df.to_string(index=False))
+
+                results.append({
+                    "page": page_num + 1,
+                    "table_index": i,
+                    "columns": header,
+                    "rows": rows,
+                })
+
+    return results
+
+
+def save_results(results: list[dict], out_path: str = "pdfplumber_output.json"):
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+    print(f"\nSaved {len(results)} table(s) to {out_path}")
+
+
+if __name__ == "__main__":
+    print("=== Testing page 5 ===")
+    extract_glossary_tables(PDF_PATH, pages=[4])
+
+    print("\n=== Extracting all pages ===")
+    all_results = extract_glossary_tables(PDF_PATH)
+    save_results(all_results)


### PR DESCRIPTION
## Summary

- Adds `src/moore_web/glossary_parser.py` to parse two PDF glossaries (Mooré + French lexique) and produce aligned French/Mooré pairs
- Adds `--source digital` to the `e2e` CLI command, mirroring the `simple` source pattern with `--terms`, `--definitions`, and `--definitions-output` flags

## Glossary parser

Extracts tables from both PDFs using `pdfplumber` with tuned settings (`edge_min_length=50`) to filter out decorative page borders. Falls back to looser settings for pages where a section-letter box confuses line detection.

**Alignment uses a three-pass heuristic:**
1. Exact normalized match (lowercase + strip diacritics)
2. Acronym-in-parentheses — e.g. `ADSL` matches `Asymetric Digital Subscriber Line (ADSL)`
3. Space-collapse for PDF line-break artefacts — e.g. `Communicatio ns électroniques` → `Communications électroniques`

**Result:** 135 / 233 Mooré entries matched (57.9%). The remaining ~42% are terms genuinely absent from the French lexique.

**Other features:**
- Unicode normalizer for typographic punctuation (curly quotes `'` `"`, en/em dashes, ellipsis, non-breaking spaces)
- `skip_preface=True` (default) omits intro/preface text segments unrelated to the glossary

## CLI usage

```bash
# Terms only (default)
moore-web e2e -s digital --fr-input lexique.pdf --mo-input glossaire.pdf -o terms.jsonl --jsonl

# Both outputs in one pass — PDFs parsed once
moore-web e2e -s digital --fr-input lexique.pdf --mo-input glossaire.pdf \
  -o terms.jsonl --definitions-output defs.jsonl --jsonl \
  --add-laser-score --add-comet-qe --add-quality-warn
```

## Test plan

- [x] `python -m moore_web.glossary_parser` extracts 233 Mooré + 872 French entries and writes 135 aligned pairs
- [x] `moore-web e2e -s digital --terms` produces 135 term pairs
- [x] `moore-web e2e -s digital --definitions-output defs.jsonl` writes both files in one pass
- [x] Unicode normalizer leaves no curly quotes in output
- [x] `--source` guard rejects `--terms/--definitions/--definitions-output` for non-digital sources