### PR TITLE
feat: separate len_ratio annotation from quality_warnings

### DIFF
--- a/src/moore_web/annotate.py
+++ b/src/moore_web/annotate.py
@@ -12,8 +12,8 @@ New columns per function
 - :func:`run_lang_id`          → ``{src}_glotlid_lang``, ``{src}_glotlid_prob``,
                                   ``{tgt}_glotlid_lang``, ``{tgt}_glotlid_prob``
                                   (column names derived from ``src_field`` / ``tgt_field``)
-- :func:`run_quality_warnings` → ``quality_warnings`` (list[str]), ``identification_consistency`` (float),
-                                  ``len_ratio`` (float)
+- :func:`run_quality_warnings` → ``quality_warnings`` (list[str]), ``identification_consistency`` (float)
+- :func:`run_len_ratio`        → ``len_ratio`` (float)
 - :func:`run_laser`            → ``laser_score`` (float)
 - :func:`run_comet_qe`         → ``comet_qe`` (float)
 
@@ -180,14 +180,13 @@ def run_quality_warnings(
 ):
     """Add quality-warning annotations to each row.
 
-    Adds three columns:
+    Adds two columns:
 
     - ``quality_warnings`` — list of active warning labels
       (``"emoji"``, ``"dots_asymmetry"``, ``"number_mismatch"``,
       ``"parenthesis_asymmetry"``, ``"bullet_asymmetry"``, ``"foreign_words"``).
     - ``identification_consistency`` — float in [0, 1]: fraction of target tokens
       absent from the foreign word list (higher = more Mooré-consistent).
-    - ``len_ratio`` — float in [0, 1]: ``min(len(src), len(tgt)) / max(len(src), len(tgt))``.
 
     Args:
         dataset:        Input ``datasets.Dataset``.
@@ -208,6 +207,41 @@ def run_quality_warnings(
         lambda batch: annotate_warnings(batch, foreign_wordlist, src_col=src_field, tgt_col=tgt_field),
         batched=True,
         desc="quality warnings",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Annotation: length ratio
+# ---------------------------------------------------------------------------
+
+
+def run_len_ratio(
+    dataset,
+    src_field: str = "french",
+    tgt_field: str = "moore",
+):
+    """Add character-length ratio between source and target sentences.
+
+    Adds one column:
+
+    - ``len_ratio`` — float in [0, 1]: ``min(len(src), len(tgt)) / max(len(src), len(tgt))``.
+      A value close to 1.0 means both sentences are similar in length; 0.0 when either is empty.
+
+    Args:
+        dataset:    Input ``datasets.Dataset``.
+        src_field:  Source column name (default: ``"french"``).
+        tgt_field:  Target column name (default: ``"moore"``).
+
+    Returns:
+        Annotated ``datasets.Dataset``.
+    """
+    from moore_web.filter_nllb import annotate_len_ratio
+
+    print(f"Annotating len_ratio ({len(dataset):,} rows)…")
+    return dataset.map(
+        lambda batch: annotate_len_ratio(batch, src_col=src_field, tgt_col=tgt_field),
+        batched=True,
+        desc="len_ratio",
     )
 
 
@@ -320,6 +354,7 @@ def annotate(
     lang_id: bool = False,
     quality_warn: bool = False,
     consistency: bool = False,
+    len_ratio: bool = False,
     laser: bool = False,
     comet_qe: bool = False,
     load_wordlists: bool = True,
@@ -341,6 +376,7 @@ def annotate(
         lang_id:           Add GlotLID language-ID columns.
         quality_warn:      Add ``quality_warnings`` column.
         consistency:       Add ``identification_consistency`` column.
+        len_ratio:         Add ``len_ratio`` column.
         laser:             Add ``laser_score`` column.
         comet_qe:          Add ``comet_qe`` column.
         load_wordlists:    Load foreign-word lists for quality-warning checks.
@@ -365,6 +401,9 @@ def annotate(
             tgt_field=tgt_field,
             load_wordlists=load_wordlists,
         )
+
+    if len_ratio:
+        dataset = run_len_ratio(dataset, src_field=src_field, tgt_field=tgt_field)
 
     if laser:
         laser_kwargs = {}

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -116,13 +116,14 @@ def _finalize_aligned(
     add_lang_id: bool,
     add_consistency: bool,
     add_quality_warn: bool,
+    add_len_ratio: bool,
     add_laser_score: bool,
     add_comet_qe: bool,
     postprocess: Callable[[list[dict]], list[dict]] | None = None,
 ) -> None:
     """Write aligned corpus, optionally annotating and/or pushing to HF Hub."""
     out_str = str(out)
-    needs_annotation = any([add_lang_id, add_consistency, add_quality_warn, add_laser_score, add_comet_qe])
+    needs_annotation = any([add_lang_id, add_consistency, add_quality_warn, add_len_ratio, add_laser_score, add_comet_qe])
     is_hf = out_str.startswith("hf://")
 
     if needs_annotation or is_hf or postprocess:
@@ -154,6 +155,7 @@ def _finalize_aligned(
                 lang_id=add_lang_id,
                 quality_warn=add_quality_warn,
                 consistency=add_consistency,
+                len_ratio=add_len_ratio,
                 laser=add_laser_score,
                 comet_qe=add_comet_qe,
             )
@@ -668,6 +670,9 @@ def annotate(
     quality_warn: Annotated[
         bool, typer.Option("--quality-warn", is_flag=True, help="Add quality_warnings list.")
     ] = False,
+    len_ratio: Annotated[
+        bool, typer.Option("--len-ratio", is_flag=True, help="Add len_ratio (character-length ratio).")
+    ] = False,
     laser_score: Annotated[
         bool, typer.Option("--laser-score", is_flag=True, help="Add LASER cosine similarity.")
     ] = False,
@@ -708,12 +713,12 @@ def annotate(
     from moore_web import annotate as _ann
 
     if all_annotations:
-        lang_id = consistency = quality_warn = laser_score = comet_qe = True
+        lang_id = consistency = quality_warn = len_ratio = laser_score = comet_qe = True
 
-    if not any([lang_id, consistency, quality_warn, laser_score, comet_qe]):
+    if not any([lang_id, consistency, quality_warn, len_ratio, laser_score, comet_qe]):
         _err(
             "No annotation flags specified. Pass at least one of: --lang-id, --consistency, "
-            "--quality-warn, --laser-score, --comet-qe."
+            "--quality-warn, --len-ratio, --laser-score, --comet-qe."
         )
         raise typer.Exit(1)
 
@@ -725,6 +730,7 @@ def annotate(
         lang_id=lang_id,
         quality_warn=quality_warn,
         consistency=consistency,
+        len_ratio=len_ratio,
         laser=laser_score,
         comet_qe=comet_qe,
         src_lang=src_lang,
@@ -929,6 +935,10 @@ def e2e(
             "--add-quality-warn", is_flag=True, help="Annotate aligned output with quality_warnings."
         ),
     ] = False,
+    add_len_ratio: Annotated[
+        bool,
+        typer.Option("--add-len-ratio", is_flag=True, help="Annotate aligned output with len_ratio."),
+    ] = False,
     add_laser_score: Annotated[
         bool,
         typer.Option(
@@ -975,7 +985,7 @@ def e2e(
     [bold]HF output:[/bold]         moore-web e2e -s sida -i book.pdf -o hf://owner/repo --annotate
     """
     if do_annotate:
-        add_lang_id = add_consistency = add_quality_warn = add_laser_score = add_comet_qe = True
+        add_lang_id = add_consistency = add_quality_warn = add_len_ratio = add_laser_score = add_comet_qe = True
 
     if (split_synonyms or strip_proverb_notes) and source != Source.simple:
         _err("--split-synonyms / --strip-proverb-notes are only supported for --source simple.")
@@ -1012,6 +1022,7 @@ def e2e(
         add_lang_id=add_lang_id,
         add_consistency=add_consistency,
         add_quality_warn=add_quality_warn,
+        add_len_ratio=add_len_ratio,
         add_laser_score=add_laser_score,
         add_comet_qe=add_comet_qe,
         hf_private=hf_private,

--- a/src/moore_web/filter_nllb.py
+++ b/src/moore_web/filter_nllb.py
@@ -251,8 +251,6 @@ def annotate_warnings(
     ``identification_consistency`` is a float in [0, 1]: fraction of Mooré
     tokens that do NOT appear in the foreign (French/English) word list.
 
-    ``len_ratio`` is a float in [0, 1]: min(len(src), len(tgt)) / max(len(src), len(tgt)).
-
     Args:
         batch:            Batched dict of column lists.
         foreign_wordlist: Set of foreign tokens to check against.
@@ -265,7 +263,6 @@ def annotate_warnings(
 
     quality_warnings = []
     id_consistency = []
-    len_ratios = []
 
     for i in range(n):
         src = src_texts[i] or ""
@@ -289,11 +286,32 @@ def annotate_warnings(
 
         quality_warnings.append(warnings)
         id_consistency.append(_lang_consistency_score(tgt, foreign_wordlist))
-        len_ratios.append(_len_ratio(src, tgt))
 
     batch["quality_warnings"] = quality_warnings
     batch["identification_consistency"] = id_consistency
-    batch["len_ratio"] = len_ratios
+
+
+def annotate_len_ratio(
+    batch: dict[str, list],
+    src_col: str = _COL_ENG,
+    tgt_col: str = _COL_MOS,
+) -> dict[str, list]:
+    """Add ``len_ratio`` column: ``min(len(src), len(tgt)) / max(len(src), len(tgt))``.
+
+    A ratio close to 1.0 means the two sentences are similar in character length.
+    Returns 0.0 when either side is empty.
+
+    Args:
+        batch:   Batched dict of column lists.
+        src_col: Column name for the source text (default: ``"eng_Latn"``).
+        tgt_col: Column name for the target text (default: ``"mos_Latn"``).
+    """
+    src_texts = batch[src_col]
+    tgt_texts = batch[tgt_col]
+    batch["len_ratio"] = [
+        _len_ratio(src or "", tgt or "") for src, tgt in zip(src_texts, tgt_texts)
+    ]
+    return batch
 
     return batch
 

--- a/src/moore_web/filter_nllb.py
+++ b/src/moore_web/filter_nllb.py
@@ -289,6 +289,7 @@ def annotate_warnings(
 
     batch["quality_warnings"] = quality_warnings
     batch["identification_consistency"] = id_consistency
+    return batch
 
 
 def annotate_len_ratio(

--- a/src/moore_web/simple_parser.py
+++ b/src/moore_web/simple_parser.py
@@ -67,7 +67,7 @@ EXTRA_FIELDS_BETTER = [
 
 
 GRAMMAR_PATTERN = (
-    r"part\.gram|expr\.|indéf\.|num|n\.pl|interj|aux|<Not Sure>|"
+    r"part\.gram|expr\.|indéf\.|num|n\.pl|interj|aux|<Not\ Sure>|"
     r"n\.propre|postpos|Verbe|adj|n\b|v(?::Any)?|dém|Nom|inter\.|"
     r"Adjectif|verbe\.it|v\.inacc|conj|pron|adv"
 )

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -18,6 +18,7 @@ from moore_web.annotate import (
     run_comet_qe,
     run_lang_id,
     run_laser,
+    run_len_ratio,
     run_quality_warnings,
     save_data,
 )
@@ -151,10 +152,6 @@ class TestRunQualityWarnings:
         result = run_quality_warnings(small_dataset, load_wordlists=False)
         assert "identification_consistency" in result.column_names
 
-    def test_adds_len_ratio_column(self, small_dataset: Dataset):
-        result = run_quality_warnings(small_dataset, load_wordlists=False)
-        assert "len_ratio" in result.column_names
-
     def test_preserves_original_columns(self, small_dataset: Dataset):
         result = run_quality_warnings(small_dataset, load_wordlists=False)
         assert "french" in result.column_names
@@ -170,22 +167,6 @@ class TestRunQualityWarnings:
         result = run_quality_warnings(small_dataset, load_wordlists=False)
         for score in result["identification_consistency"]:
             assert 0.0 <= score <= 1.0
-
-    def test_len_ratio_in_range(self, small_dataset: Dataset):
-        result = run_quality_warnings(small_dataset, load_wordlists=False)
-        for ratio in result["len_ratio"]:
-            assert 0.0 <= ratio <= 1.0
-
-    def test_len_ratio_symmetric(self):
-        ds = Dataset.from_list(
-            [
-                {"french": "ab", "moore": "abcd"},
-                {"french": "abcd", "moore": "ab"},
-            ]
-        )
-        result = run_quality_warnings(ds, load_wordlists=False)
-        assert result["len_ratio"][0] == result["len_ratio"][1]
-        assert result["len_ratio"][0] == pytest.approx(0.5)
 
     def test_custom_field_names(self):
         ds = Dataset.from_list([{"src": "Bonjour", "tgt": "Yibeogo"}])
@@ -208,6 +189,42 @@ class TestRunQualityWarnings:
     def test_row_count_unchanged(self, small_dataset: Dataset):
         result = run_quality_warnings(small_dataset, load_wordlists=False)
         assert len(result) == len(small_dataset)
+
+
+# ---------------------------------------------------------------------------
+# run_len_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestRunLenRatio:
+    def test_adds_len_ratio_column(self, small_dataset: Dataset):
+        result = run_len_ratio(small_dataset)
+        assert "len_ratio" in result.column_names
+
+    def test_len_ratio_in_range(self, small_dataset: Dataset):
+        result = run_len_ratio(small_dataset)
+        for ratio in result["len_ratio"]:
+            assert 0.0 <= ratio <= 1.0
+
+    def test_len_ratio_symmetric(self):
+        ds = Dataset.from_list(
+            [
+                {"french": "ab", "moore": "abcd"},
+                {"french": "abcd", "moore": "ab"},
+            ]
+        )
+        result = run_len_ratio(ds)
+        assert result["len_ratio"][0] == result["len_ratio"][1]
+        assert result["len_ratio"][0] == pytest.approx(0.5)
+
+    def test_preserves_original_columns(self, small_dataset: Dataset):
+        result = run_len_ratio(small_dataset)
+        assert "french" in result.column_names
+        assert "moore" in result.column_names
+
+    def test_does_not_add_quality_warnings(self, small_dataset: Dataset):
+        result = run_len_ratio(small_dataset)
+        assert "quality_warnings" not in result.column_names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extracts `len_ratio` out of `annotate_warnings` in `filter_nllb.py` into its own `annotate_len_ratio` batch function
- Adds `run_len_ratio` in `annotate.py` as a standalone annotation step (previously bundled inside `run_quality_warnings`)
- Exposes `--len-ratio` flag in the `annotate` CLI command and `--add-len-ratio` in the `e2e` command

## Test plan

- [x] `moore-web annotate -i data.jsonl -o out.jsonl --len-ratio` adds only `len_ratio` column (no `quality_warnings`)
- [x] `moore-web annotate -i data.jsonl -o out.jsonl --quality-warn` adds `quality_warnings` and `identification_consistency` but not `len_ratio`
- [x] `moore-web annotate -i data.jsonl -o out.jsonl --all` still produces all columns including `len_ratio`
- [x] `moore-web e2e ... --add-len-ratio` wires through correctly