### PR TITLE
feat: add parser for Du Moore au Français PDF series

### DIFF
--- a/build_fr_mos_dataset.py
+++ b/build_fr_mos_dataset.py
@@ -97,14 +97,16 @@ def _load_jsonl(path: Path, source_override: str | None = None) -> list[dict]:
             if not fr or not mo:
                 continue
             src = source_override if source_override is not None else obj.get("source", "unknown")
-            rows.append({
-                "french": fr,
-                "moore": mo,
-                "source": src,
-                "laser_score": obj.get("laser_score"),
-                "comet_qe": obj.get("comet_qe"),
-                "len_ratio": obj.get("len_ratio"),
-            })
+            rows.append(
+                {
+                    "french": fr,
+                    "moore": mo,
+                    "source": src,
+                    "laser_score": obj.get("laser_score"),
+                    "comet_qe": obj.get("comet_qe"),
+                    "len_ratio": obj.get("len_ratio"),
+                }
+            )
     return rows
 
 
@@ -129,8 +131,8 @@ def _print_source_breakdown(rows: list[dict], label: str) -> None:
 # ---------------------------------------------------------------------------
 
 _FILTERS: dict[str, tuple[str, float]] = {
-    "len_ratio":   (">",  0.1),
-    "comet_qe":    (">=", 0.35),
+    "len_ratio": (">", 0.1),
+    "comet_qe": (">=", 0.35),
     "laser_score": (">=", 0.5),
 }
 
@@ -253,8 +255,7 @@ def build(
             deduped.append(r)
     n_dropped = len(local_all) - len(deduped)
     if n_dropped:
-        print(f"\n  dedup: dropped {n_dropped:,} duplicate (fr, mos) pairs "
-              f"→ {len(deduped):,} unique rows")
+        print(f"\n  dedup: dropped {n_dropped:,} duplicate (fr, mos) pairs → {len(deduped):,} unique rows")
     local_all = deduped
 
     # ---- Quality filter -----------------------------------------------------
@@ -265,20 +266,17 @@ def build(
     train_only = [r for r in local_all if r["source"] in train_only_sources]
     splittable = [r for r in local_all if r["source"] not in train_only_sources]
 
-    print(f"\nEval-eligible rows: {len(splittable):,}  "
-          f"(train-only: {len(train_only):,})")
+    print(f"\nEval-eligible rows: {len(splittable):,}  (train-only: {len(train_only):,})")
 
     # ---- 2. Stratified split of splittable rows ----------------------------
     print(f"\nBuilding stratified split  dev={dev_size}  test={test_size}  seed={seed} …")
-    local_train, local_dev, local_test = _stratified_split(
-        splittable, dev_size, test_size, seed
-    )
+    local_train, local_dev, local_test = _stratified_split(splittable, dev_size, test_size, seed)
     local_train = train_only + local_train  # re-attach train-only rows
 
     print("  Local split:")
     _print_source_breakdown(local_train, "train")
-    _print_source_breakdown(local_dev,   "dev  ")
-    _print_source_breakdown(local_test,  "test ")
+    _print_source_breakdown(local_dev, "dev  ")
+    _print_source_breakdown(local_test, "test ")
 
     # ---- 3. mafand splits --------------------------------------------------
     mafand_train: list[dict] = []
@@ -303,14 +301,16 @@ def build(
                 mo = (row.get("moore") or "").strip()
                 src = row.get("source") or "mafand"
                 if fr and mo:
-                    target.append({
-                        "french": fr,
-                        "moore": mo,
-                        "source": src,
-                        "laser_score": row.get("laser_score"),
-                        "comet_qe": row.get("comet_qe"),
-                        "len_ratio": row.get("len_ratio"),
-                    })
+                    target.append(
+                        {
+                            "french": fr,
+                            "moore": mo,
+                            "source": src,
+                            "laser_score": row.get("laser_score"),
+                            "comet_qe": row.get("comet_qe"),
+                            "len_ratio": row.get("len_ratio"),
+                        }
+                    )
             print(f"  {split_name}: {len(target):,} rows")
 
     # ---- 4. Merge ----------------------------------------------------------
@@ -322,8 +322,8 @@ def build(
 
     print("\nFinal dataset:")
     _print_source_breakdown(final_train, "train")
-    _print_source_breakdown(final_dev,   "dev  ")
-    _print_source_breakdown(final_test,  "test ")
+    _print_source_breakdown(final_dev, "dev  ")
+    _print_source_breakdown(final_test, "test ")
     total = len(final_train) + len(final_dev) + len(final_test)
     print(f"  total: {total:,}")
 
@@ -331,8 +331,8 @@ def build(
     if output_dir:
         print(f"\nWriting to {output_dir}/ …")
         _write_jsonl(final_train, output_dir / "train.jsonl")
-        _write_jsonl(final_dev,   output_dir / "dev.jsonl")
-        _write_jsonl(final_test,  output_dir / "test.jsonl")
+        _write_jsonl(final_dev, output_dir / "dev.jsonl")
+        _write_jsonl(final_test, output_dir / "test.jsonl")
 
     # ---- 6. Push to Hub ----------------------------------------------------
     if push_to_hub:
@@ -340,13 +340,17 @@ def build(
 
         print(f"\nPushing to {push_to_hub} …")
         _drop_cols = {"quality_warnings"}
+
         def _strip(rows: list[dict]) -> list[dict]:
             return [{k: v for k, v in r.items() if k not in _drop_cols} for r in rows]
-        dataset_dict = DatasetDict({
-            "train":      Dataset.from_list(_strip(final_train)),
-            "validation": Dataset.from_list(_strip(final_dev)),
-            "test":       Dataset.from_list(_strip(final_test)),
-        })
+
+        dataset_dict = DatasetDict(
+            {
+                "train": Dataset.from_list(_strip(final_train)),
+                "validation": Dataset.from_list(_strip(final_dev)),
+                "test": Dataset.from_list(_strip(final_test)),
+            }
+        )
         dataset_dict.push_to_hub(push_to_hub, private=hub_private)
         print(f"Done. https://huggingface.co/datasets/{push_to_hub}")
 
@@ -373,7 +377,7 @@ def _parse_args() -> argparse.Namespace:
         default="madoss/mafand-fr-mos",
         metavar="REPO_ID",
         help="HF Hub repo for mafand splits (default: %(default)s). "
-             "Pass empty string or use --no-mafand to skip.",
+        "Pass empty string or use --no-mafand to skip.",
     )
     parser.add_argument(
         "--no-mafand",
@@ -415,8 +419,7 @@ def _parse_args() -> argparse.Namespace:
         nargs="+",
         default=list(_DEFAULT_TRAIN_ONLY),
         metavar="SOURCE",
-        help="Source tags that must stay in train only "
-             "(default: %(default)s).",
+        help="Source tags that must stay in train only (default: %(default)s).",
     )
     parser.add_argument(
         "--seed",

--- a/comet_flores.py
+++ b/comet_flores.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# flores_qe.py
+
+import argparse
+import numpy as np
+from datasets import load_dataset
+from comet import download_model, load_from_checkpoint
+
+
+def main():
+    parser = argparse.ArgumentParser(description="COMET-QE scoring on FLORES+ language pairs")
+    parser.add_argument("--src", default="eng_Latn", help="Source language code (e.g. eng_Latn)")
+    parser.add_argument("--tgt", default="mos_Latn", help="Target language code (e.g. mos_Latn)")
+    parser.add_argument("--split", default="dev", choices=["dev", "devtest"], help="FLORES+ split to use")
+    parser.add_argument("--model", default="McGill-NLP/ssa-comet-qe", help="COMET model to use")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--gpus", type=int, default=1)
+    parser.add_argument("--output", help="Output CSV path (default: comet_qe_{src}_{tgt}.csv)")
+    args = parser.parse_args()
+
+    src, tgt = args.src, args.tgt
+    output_path = args.output or f"comet_qe_{src}_{tgt}.csv"
+    col_name = f"comet_qe_{src}_{tgt}"
+
+    ds_src = load_dataset("openlanguagedata/flores_plus", src, split=args.split)
+    ds_tgt = load_dataset("openlanguagedata/flores_plus", tgt, split=args.split)
+
+    ds_src = ds_src.select_columns(["id", "topic", "text"]).rename_column("text", src)
+    ds_tgt = ds_tgt.select_columns(["id", "topic", "text"]).rename_column("text", tgt)
+
+    merged = ds_src.add_column(tgt, ds_tgt[tgt])
+
+    model_path = download_model(args.model)
+    model = load_from_checkpoint(model_path)
+
+    data = [{"src": row[src], "mt": row[tgt]} for row in merged]
+    output = model.predict(data, batch_size=args.batch_size, gpus=args.gpus)
+
+    merged = merged.add_column(col_name, output.scores)
+
+    scores = np.array(output.scores)
+    print(f"\n=== QE Score Stats ({src} → {tgt}, {len(scores)} sentences) ===")
+    print(f"  Mean:   {scores.mean():.4f}")
+    print(f"  Median: {np.median(scores):.4f}")
+    print(f"  Std:    {scores.std():.4f}")
+    print(f"  Min:    {scores.min():.4f}")
+    print(f"  Max:    {scores.max():.4f}")
+
+    print("\n=== Per-topic Mean QE Score ===")
+    topics = merged["topic"]
+    for topic in sorted(set(topics)):
+        topic_scores = scores[[i for i, t in enumerate(topics) if t == topic]]
+        print(f"  {topic:<30} {topic_scores.mean():.4f}  (n={len(topic_scores)})")
+
+    print("\n=== Score Distribution ===")
+    for low, high in [(0.0, 0.2), (0.2, 0.4), (0.4, 0.6), (0.6, 0.8), (0.8, 1.0)]:
+        count = ((scores >= low) & (scores < high)).sum()
+        print(f"  [{low:.1f}, {high:.1f}): {count:>4} ({100 * count / len(scores):.1f}%)")
+
+    merged.to_csv(output_path, index=False)
+    print(f"\nSaved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/explore_aligned.py
+++ b/notebooks/explore_aligned.py
@@ -16,7 +16,7 @@ Run with:
 
 import marimo
 
-__generated_with = "0.23.0"
+__generated_with = "0.23.1"
 app = marimo.App(width="medium", app_title="Aligned Corpus Explorer")
 
 
@@ -35,7 +35,7 @@ def _():
 @app.cell
 def _(mo):
     file_path_input = mo.ui.text(
-        value="final_data_hf/conseils_ministres_aligned.jsonl",
+        value="final_data_hf/sida_aligned.jsonl",
         label="Aligned JSON path",
         placeholder="aligned.jsonl",
         full_width=True,

--- a/src/moore_web/cli.py
+++ b/src/moore_web/cli.py
@@ -123,7 +123,9 @@ def _finalize_aligned(
 ) -> None:
     """Write aligned corpus, optionally annotating and/or pushing to HF Hub."""
     out_str = str(out)
-    needs_annotation = any([add_lang_id, add_consistency, add_quality_warn, add_len_ratio, add_laser_score, add_comet_qe])
+    needs_annotation = any(
+        [add_lang_id, add_consistency, add_quality_warn, add_len_ratio, add_laser_score, add_comet_qe]
+    )
     is_hf = out_str.startswith("hf://")
 
     if needs_annotation or is_hf or postprocess:
@@ -985,7 +987,9 @@ def e2e(
     [bold]HF output:[/bold]         moore-web e2e -s sida -i book.pdf -o hf://owner/repo --annotate
     """
     if do_annotate:
-        add_lang_id = add_consistency = add_quality_warn = add_len_ratio = add_laser_score = add_comet_qe = True
+        add_lang_id = add_consistency = add_quality_warn = add_len_ratio = add_laser_score = add_comet_qe = (
+            True
+        )
 
     if (split_synonyms or strip_proverb_notes) and source != Source.simple:
         _err("--split-synonyms / --strip-proverb-notes are only supported for --source simple.")
@@ -1214,7 +1218,9 @@ def e2e(
 
     elif source == Source.digital:
         if fr_input is None or mo_input is None:
-            _err("--fr-input (French lexique PDF) and --mo-input (Mooré glossaire PDF) are required for --source digital.")
+            _err(
+                "--fr-input (French lexique PDF) and --mo-input (Mooré glossaire PDF) are required for --source digital."
+            )
             raise typer.Exit(1)
 
         from moore_web.flatten import AlignedCorpus
@@ -1233,7 +1239,9 @@ def e2e(
         typer.echo("[2/2] Aligning…")
         pairs = align_glossaries(moore_entries, french_entries)
         if moore_entries:
-            typer.echo(f"      Matched: {len(pairs)} / {len(moore_entries)} ({len(pairs)/len(moore_entries)*100:.1f}%)")
+            typer.echo(
+                f"      Matched: {len(pairs)} / {len(moore_entries)} ({len(pairs) / len(moore_entries) * 100:.1f}%)"
+            )
 
         def _write_digital(inc_terms: bool, inc_definitions: bool, dest) -> None:
             _Scores = list[float | None]
@@ -1267,11 +1275,15 @@ def e2e(
                 source=label,
             )
             # Terms are exact key matches — LASER/COMET-QE add no information.
-            ann = _ann_kwargs if not (inc_terms and not inc_definitions) else {
-                **_ann_kwargs,
-                "add_laser_score": False,
-                "add_comet_qe": False,
-            }
+            ann = (
+                _ann_kwargs
+                if not (inc_terms and not inc_definitions)
+                else {
+                    **_ann_kwargs,
+                    "add_laser_score": False,
+                    "add_comet_qe": False,
+                }
+            )
             typer.echo(f"      FR: {len(fr_texts)}  MO: {len(mo_texts)}  → {dest}")
             _finalize_aligned(a, dest, jsonl, **ann)
 

--- a/src/moore_web/filter_nllb.py
+++ b/src/moore_web/filter_nllb.py
@@ -309,9 +309,7 @@ def annotate_len_ratio(
     """
     src_texts = batch[src_col]
     tgt_texts = batch[tgt_col]
-    batch["len_ratio"] = [
-        _len_ratio(src or "", tgt or "") for src, tgt in zip(src_texts, tgt_texts)
-    ]
+    batch["len_ratio"] = [_len_ratio(src or "", tgt or "") for src, tgt in zip(src_texts, tgt_texts)]
     return batch
 
     return batch

--- a/src/moore_web/flatten.py
+++ b/src/moore_web/flatten.py
@@ -105,8 +105,7 @@ class AlignedCorpus(ParallelText):
 
         if has_english:
             return [
-                _row(f, m, s, en)
-                for f, m, s, en in zip(self.french, self.moore, self.scores, self.english)
+                _row(f, m, s, en) for f, m, s, en in zip(self.french, self.moore, self.scores, self.english)
             ]
         return [_row(f, m, s) for f, m, s in zip(self.french, self.moore, self.scores)]
 

--- a/src/moore_web/glossary_parser.py
+++ b/src/moore_web/glossary_parser.py
@@ -108,22 +108,22 @@ _HEADER_KEYWORDS_FRENCH = {"N°", "Mots", "clés", "Définitions"}
 # Typographic characters → plain ASCII equivalents
 _UNICODE_MAP = str.maketrans(
     {
-        "\u2018": "'",   # '  LEFT SINGLE QUOTATION MARK
-        "\u2019": "'",   # '  RIGHT SINGLE QUOTATION MARK  ← reported
-        "\u201a": "'",   # ‚  SINGLE LOW-9 QUOTATION MARK
-        "\u201b": "'",   # ‛  SINGLE HIGH-REVERSED-9 QUOTATION MARK
-        "\u201c": '"',   # "  LEFT DOUBLE QUOTATION MARK
-        "\u201d": '"',   # "  RIGHT DOUBLE QUOTATION MARK
-        "\u201e": '"',   # „  DOUBLE LOW-9 QUOTATION MARK
-        "\u2013": "-",   # –  EN DASH
-        "\u2014": "-",   # —  EM DASH
-        "\u2015": "-",   # ―  HORIZONTAL BAR
-        "\u2026": "...", # …  HORIZONTAL ELLIPSIS
-        "\u00a0": " ",   # non-breaking space
-        "\u202f": " ",   # narrow no-break space
-        "\u2009": " ",   # thin space
-        "\u00ab": '"',   # «  LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-        "\u00bb": '"',   # »  RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+        "\u2018": "'",  # '  LEFT SINGLE QUOTATION MARK
+        "\u2019": "'",  # '  RIGHT SINGLE QUOTATION MARK  ← reported
+        "\u201a": "'",  # ‚  SINGLE LOW-9 QUOTATION MARK
+        "\u201b": "'",  # ‛  SINGLE HIGH-REVERSED-9 QUOTATION MARK
+        "\u201c": '"',  # "  LEFT DOUBLE QUOTATION MARK
+        "\u201d": '"',  # "  RIGHT DOUBLE QUOTATION MARK
+        "\u201e": '"',  # „  DOUBLE LOW-9 QUOTATION MARK
+        "\u2013": "-",  # –  EN DASH
+        "\u2014": "-",  # —  EM DASH
+        "\u2015": "-",  # ―  HORIZONTAL BAR
+        "\u2026": "...",  # …  HORIZONTAL ELLIPSIS
+        "\u00a0": " ",  # non-breaking space
+        "\u202f": " ",  # narrow no-break space
+        "\u2009": " ",  # thin space
+        "\u00ab": '"',  # «  LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+        "\u00bb": '"',  # »  RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
     }
 )
 
@@ -185,8 +185,8 @@ def _best_table(page, min_cols: int) -> list[list[str]] | None:
 
 MOORE_PDF = "Glossaire_des_termes_usuels_du_numerique_et_de_la_poste_en_Moore__valide.pdf"
 
-_MOORE_TEXT_PAGE_RANGE = (1, 3)   # 1-based inclusive
-_MOORE_SKIP_PAGES = {4}           # section header pages (1-based)
+_MOORE_TEXT_PAGE_RANGE = (1, 3)  # 1-based inclusive
+_MOORE_SKIP_PAGES = {4}  # section header pages (1-based)
 
 
 def _parse_moore_row(row: list[str], ncols: int) -> MooreEntry | None:
@@ -251,9 +251,9 @@ def extract_moore_text_segments(pdf_path: str = MOORE_PDF) -> list[TextSegment]:
 
 FRENCH_PDF = "Lexique_de_l_economie_numerique_et_des_postes.pdf"
 
-_FRENCH_TEXT_PAGE_RANGE = (1, 4)   # 1-based inclusive
-_FRENCH_SKIP_PAGES = {5}           # section header pages (1-based)
-_FRENCH_TABLE_LAST_PAGE = 86       # 1-based; pages 87-94 are appendices
+_FRENCH_TEXT_PAGE_RANGE = (1, 4)  # 1-based inclusive
+_FRENCH_SKIP_PAGES = {5}  # section header pages (1-based)
+_FRENCH_TABLE_LAST_PAGE = 86  # 1-based; pages 87-94 are appendices
 
 
 def extract_french_tables(pdf_path: str = FRENCH_PDF) -> list[FrenchEntry]:
@@ -318,9 +318,7 @@ def align_glossaries(
         Collapsing all whitespace before comparing catches these.
     """
     # Pass 1 index: normalised term → entry
-    fr_exact: dict[str, FrenchEntry] = {
-        _normalize_key(fe.fr_term): fe for fe in french_entries
-    }
+    fr_exact: dict[str, FrenchEntry] = {_normalize_key(fe.fr_term): fe for fe in french_entries}
 
     # Pass 2 index: normalised text-in-parens → entry
     fr_paren: dict[str, FrenchEntry] = {}
@@ -340,11 +338,7 @@ def align_glossaries(
             continue
 
         key = _normalize_key(me.fr_term)
-        fe = (
-            fr_exact.get(key)
-            or fr_paren.get(key)
-            or fr_nospace.get(re.sub(r"\s+", "", key))
-        )
+        fe = fr_exact.get(key) or fr_paren.get(key) or fr_nospace.get(re.sub(r"\s+", "", key))
         if fe:
             aligned.append(
                 AlignedEntry(
@@ -408,8 +402,10 @@ def parse_glossaries(
     aligned = align_glossaries(moore_entries, french_entries)
     _write_jsonl(aligned, out / "aligned.jsonl")
     if moore_entries:
-        print(f"  matched {len(aligned)} / {len(moore_entries)} Mooré entries "
-              f"({len(aligned)/len(moore_entries)*100:.1f}%)")
+        print(
+            f"  matched {len(aligned)} / {len(moore_entries)} Mooré entries "
+            f"({len(aligned) / len(moore_entries) * 100:.1f}%)"
+        )
 
     if not skip_preface:
         print("Extracting Mooré text segments (pages 1-3)…")

--- a/src/moore_web/parse_du_moore.py
+++ b/src/moore_web/parse_du_moore.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+Extract parallel French-Mooré sentence pairs from "Du Moore au Français" PDFs.
+
+Each lesson occupies two consecutive pages with the same "Kaoreng … soaba"
+header.  The first page is always French, the second always Mooré.
+
+Two lesson layouts exist across the three books:
+
+  sectioned  — lessons with ① (vocab) and ② (sentences) markers
+               + a conversation/drill section
+  prose      — later lessons (book 3 lessons 40-48) with a plain numbered
+               vocab list and a reading passage instead of ①②
+"""
+
+import re
+import json
+import argparse
+from pathlib import Path
+import pdfplumber
+
+PDFS = [
+    ("Du_Moore_au_Francais_1_Noir_et_Blanc_pp_01-30_Lecons_1-16.pdf", 1),
+    ("Du_Moore_au_Francais_2_Noir_et_Blanc_pp_31-60_Lecons_17-31.pdf", 2),
+    ("Du_Moore_au_Francais_3_Noir_et_Blanc_pp.61-94_Lecons_32-48.pdf", 3),
+]
+
+LESSON_RE = re.compile(r"[Kk]aoren[ɡg].*soaba")
+SUBTITLE_RE = re.compile(r"\bkaorengo\b|\bkaorenɡo\b|\bkarem", re.IGNORECASE)
+
+CONV_HEADERS = {"D ɡom fãrende", "Kʋmbɡo"}
+CONV_STOP = {
+    "Expression libre",
+    "Gʋlsɡo",
+    "D bãnɡ n ɡʋls ne fãrende",
+    "Bãnɡ n ɡʋls ne fãrende",
+    "Bãnɡ n ɡʋls",
+}
+CONV_SKIP = {"wilɡ", "fãrendẽ wã", "à ne ɡeonf", "sũk bɩ"}
+
+PASSAGE_STOP = {"Questions de compréhension", "Ecriture", "E criture", "Copie", "C opie"}
+
+Y_TOL = 5
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+
+def page_lines(page) -> list[tuple[int, str]]:
+    """Return [(y_bucket, line_text)] sorted by y."""
+    words = page.extract_words(x_tolerance=5, y_tolerance=Y_TOL)
+    buckets: dict[int, list[str]] = {}
+    for w in words:
+        y = round(w["top"] / Y_TOL) * Y_TOL
+        buckets.setdefault(y, []).append(w["text"])
+    return [(y, " ".join(ws)) for y, ws in sorted(buckets.items())]
+
+
+def get_lesson_header(lines: list[tuple[int, str]]) -> str | None:
+    """Return the normalised lesson header line, or None."""
+    for _, text in lines:
+        if LESSON_RE.search(text) and "soaba" in text:
+            return re.sub(r"\s+", " ", text.strip())
+    return None
+
+
+def page_full_text(lines: list[tuple[int, str]]) -> str:
+    return " ".join(t for _, t in lines)
+
+
+def has_section_markers(lines: list[tuple[int, str]]) -> bool:
+    full = page_full_text(lines)
+    return "①" in full or "②" in full
+
+
+def pair_lesson_pages(pdf) -> list[tuple[list, list]]:
+    """
+    Return (fr_lines, mos_lines) pairs by matching consecutive pages that
+    share the same 'Kaoreng … soaba' header.  First page of each pair is
+    French, second is Mooré — consistent across all three books.
+    """
+    tagged = []
+    for page in pdf.pages:
+        lines = page_lines(page)
+        header = get_lesson_header(lines)
+        if header:
+            tagged.append((header, lines))
+
+    pairs = []
+    i = 0
+    while i < len(tagged):
+        if i + 1 < len(tagged) and tagged[i][0] == tagged[i + 1][0]:
+            pairs.append((tagged[i][1], tagged[i + 1][1]))
+            i += 2
+        else:
+            i += 1  # unpaired lesson page — skip
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Key sentence
+# ---------------------------------------------------------------------------
+
+
+def extract_key(lines: list[tuple[int, str]]) -> str | None:
+    """
+    First sentence-like line after the lesson header and subtitle.
+
+    The subtitle is always the first non-short, non-header line after the
+    lesson header.  SUBTITLE_RE catches most subtitles explicitly; for the
+    rest we use a positional skip (skip once, then collect).
+    """
+    past_header = False
+    subtitle_seen = False  # True once the subtitle has been consumed
+
+    for _, text in lines:
+        t = text.strip()
+        if LESSON_RE.search(t):
+            past_header = True
+            subtitle_seen = False
+            continue
+        if not past_header:
+            continue
+        if len(t) <= 4:
+            continue
+        # Explicit subtitle match — mark seen and keep scanning
+        if SUBTITLE_RE.search(t):
+            subtitle_seen = True
+            continue
+        # Positional fallback: if subtitle not yet seen, this line is it
+        if not subtitle_seen:
+            subtitle_seen = True
+            continue
+        # Stop at section markers or numbered vocab start
+        if re.match(r"[①②]", t) or re.match(r"1\s*[-–]", t):
+            break
+        if len(t) > 8 and " " in t:
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Sectioned layout: ① vocab  ②  sentences  +  conversation
+# ---------------------------------------------------------------------------
+
+
+def _parse_numbered_items(text: str) -> dict[int, str]:
+    """
+    Split 'N – word  M – word' into {N: word, M: word} using re.split so
+    that two-digit item numbers like '17' are never partially consumed.
+    """
+    parts = re.split(r"(\d+)\s*[–\-]\s*", text)
+    items: dict[int, str] = {}
+    i = 1  # parts[0] is the prefix before the first number
+    while i + 1 < len(parts):
+        num = int(parts[i])
+        val = parts[i + 1].strip()
+        if val and re.search(r"[^\W\d]", val):
+            items[num] = val
+        i += 2
+    return items
+
+
+def extract_vocab_sectioned(lines: list[tuple[int, str]]) -> dict[int, str]:
+    """Section ①: numbered items → {number: text}."""
+    items: dict[int, str] = {}
+    in_sec = False
+    for _, text in lines:
+        if "①" in text:
+            in_sec = True
+        if in_sec and "②" in text:
+            break
+        if in_sec:
+            items.update(_parse_numbered_items(text))
+    return items
+
+
+def _apply_prefix(prefix: str | None, text: str) -> str:
+    if not prefix:
+        return text
+    sep = "" if len(prefix) == 1 else " "
+    return prefix + sep + text
+
+
+def _fix_dropcap_space(text: str) -> str:
+    """'L e bébé' → 'Le bébé' (French drop-cap merged with a spurious space)."""
+    return re.sub(r"^([A-Za-zÀ-ÿ]) ([a-zà-ÿ])", lambda m: m.group(1) + m.group(2), text)
+
+
+def extract_sentences_sectioned(lines: list[tuple[int, str]], fix_dropcap: bool = False) -> list[str]:
+    """Section ②: parallel sentences in order."""
+    sents = []
+    in_sec = False
+    prefix: str | None = None
+    prev_y: int = 0
+
+    for y, text in lines:
+        if not in_sec and re.fullmatch(r"[A-Za-zÀ-ÿ]{1,4}", text.strip()):
+            prefix = text.strip()
+            prev_y = y
+            continue
+
+        if "②" in text:
+            in_sec = True
+            remainder = re.sub(r"^②\s*", "", text).strip()
+            remainder = re.sub(r"^\d+\s*[–\-]\s*", "", remainder).strip()
+            if prefix is not None and y - prev_y <= 10:
+                remainder = _apply_prefix(prefix, remainder)
+            prefix = None
+            if fix_dropcap:
+                remainder = _fix_dropcap_space(remainder)
+            if len(remainder) > 2:
+                sents.append(remainder)
+            prev_y = y
+            continue
+
+        if in_sec:
+            if any(m in text for m in CONV_HEADERS | {"Expression libre"}):
+                break
+            t = text.strip()
+            if re.fullmatch(r"[A-Za-zÀ-ÿ]{1,4}", t):
+                prefix = t
+                prev_y = y
+                continue
+            t = re.sub(r"^\d+\s*[–\-]\s*", "", t)
+            if prefix is not None and y - prev_y <= 10:
+                t = _apply_prefix(prefix, t)
+            prefix = None
+            if fix_dropcap:
+                t = _fix_dropcap_space(t)
+            if len(t) > 2:
+                sents.append(t)
+
+        prev_y = y
+    return sents
+
+
+def extract_conversation(lines: list[tuple[int, str]]) -> list[str]:
+    """D gom fãrende / Kʋmbɡo section: drill sentences."""
+    sents = []
+    in_sec = False
+    for _, text in lines:
+        t = text.strip()
+        if any(m in t for m in CONV_HEADERS):
+            in_sec = True
+            continue
+        if not in_sec:
+            continue
+        if any(m in t for m in CONV_STOP):
+            break
+        if any(s in t for s in CONV_SKIP) or len(t) < 5:
+            continue
+        if t.startswith("Makre"):
+            after = t[t.find(":") + 1 :].strip() if ":" in t else ""
+            for sent in re.split(r"\.\s+", after):
+                sent = sent.strip().rstrip(".")
+                if sent:
+                    sents.append(sent + ".")
+            continue
+        if len(t) > 5:
+            sents.append(t)
+    return sents
+
+
+# ---------------------------------------------------------------------------
+# Prose layout: plain numbered vocab  +  reading passage
+# ---------------------------------------------------------------------------
+
+
+def extract_vocab_prose(lines: list[tuple[int, str]]) -> dict[int, str]:
+    """
+    Numbered vocab list without a ① marker (prose-layout lessons).
+    Items use 'N - word' or 'N – word' format.
+    """
+    items: dict[int, str] = {}
+    in_sec = False
+    for _, text in lines:
+        if not in_sec and re.match(r"1\s*[-–]", text.strip()):
+            in_sec = True
+        if not in_sec:
+            continue
+        if not re.search(r"\d+\s*[-–]", text):
+            if len(text.strip()) > 20:
+                break  # end of vocab, passage starts
+            continue  # short interstitial line (e.g. drop-cap fragment)
+        items.update(_parse_numbered_items(text))
+    return items
+
+
+def extract_passage(lines: list[tuple[int, str]]) -> list[str]:
+    """
+    Reading passage sentences from prose-layout lessons.
+
+    Strategy:
+      1. Skip everything until the numbered vocab list starts.
+      2. Skip all numbered vocab lines.
+      3. Skip short non-sentence lines (titles, drop-cap fragments ≤ 20 chars).
+      4. Collect full sentences; merge wrapped continuation lines.
+      5. Stop at comprehension questions / writing markers.
+    """
+    sents: list[str] = []
+    past_vocab = False
+    in_passage = False
+
+    for _, text in lines:
+        t = text.strip()
+        if any(m in t for m in PASSAGE_STOP):
+            break
+        # Detect start of numbered vocab
+        if not past_vocab and re.match(r"1\s*[-–]", t):
+            past_vocab = True
+        if not past_vocab:
+            continue
+        # Skip numbered vocab lines
+        if re.search(r"\d+\s*[-–]", t):
+            continue
+        # Before passage: skip short lines (titles, interstitials)
+        if not in_passage and len(t) <= 20:
+            continue
+        # First long non-numbered line marks passage start
+        in_passage = True
+        if len(t) > 1:
+            if sents and not sents[-1].endswith((".", "!", "?")):
+                sents[-1] += " " + t  # merge wrapped line
+            else:
+                sents.append(t)
+    return sents
+
+
+# ---------------------------------------------------------------------------
+# Top-level parser
+# ---------------------------------------------------------------------------
+
+
+def parse_pdf(path: Path, book_num: int) -> list[dict]:
+    records = []
+    with pdfplumber.open(path) as pdf:
+        pairs = pair_lesson_pages(pdf)
+
+    for lesson, (fr_lines, mos_lines) in enumerate(pairs, start=1):
+        src = f"Du_Moore_{book_num}"
+
+        # Key sentence (same logic for all layouts)
+        fr_k = extract_key(fr_lines)
+        mos_k = extract_key(mos_lines)
+        if fr_k and mos_k:
+            records.append({"fr": fr_k, "mos": mos_k, "source": src, "lesson": lesson, "section": "key"})
+
+        if has_section_markers(fr_lines):
+            # --- sectioned layout ---
+            fr_v = extract_vocab_sectioned(fr_lines)
+            mos_v = extract_vocab_sectioned(mos_lines)
+            for num in sorted(set(fr_v) & set(mos_v)):
+                records.append(
+                    {
+                        "fr": fr_v[num],
+                        "mos": mos_v[num],
+                        "source": src,
+                        "lesson": lesson,
+                        "section": "vocab",
+                        "item": num,
+                    }
+                )
+
+            fr_s = extract_sentences_sectioned(fr_lines, fix_dropcap=True)
+            mos_s = extract_sentences_sectioned(mos_lines, fix_dropcap=False)
+            for j, (f, m) in enumerate(zip(fr_s, mos_s)):
+                records.append(
+                    {
+                        "fr": f,
+                        "mos": m,
+                        "source": src,
+                        "lesson": lesson,
+                        "section": "sentences",
+                        "item": j + 1,
+                    }
+                )
+
+            fr_c = extract_conversation(fr_lines)
+            mos_c = extract_conversation(mos_lines)
+            for j, (f, m) in enumerate(zip(fr_c, mos_c)):
+                records.append(
+                    {
+                        "fr": f,
+                        "mos": m,
+                        "source": src,
+                        "lesson": lesson,
+                        "section": "conversation",
+                        "item": j + 1,
+                    }
+                )
+
+        else:
+            # --- prose layout ---
+            fr_v = extract_vocab_prose(fr_lines)
+            mos_v = extract_vocab_prose(mos_lines)
+            for num in sorted(set(fr_v) & set(mos_v)):
+                records.append(
+                    {
+                        "fr": fr_v[num],
+                        "mos": mos_v[num],
+                        "source": src,
+                        "lesson": lesson,
+                        "section": "vocab",
+                        "item": num,
+                    }
+                )
+
+            fr_p = extract_passage(fr_lines)
+            mos_p = extract_passage(mos_lines)
+            for j, (f, m) in enumerate(zip(fr_p, mos_p)):
+                records.append(
+                    {"fr": f, "mos": m, "source": src, "lesson": lesson, "section": "passage", "item": j + 1}
+                )
+
+    return records
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract parallel fr-mos pairs from Du Moore PDFs")
+    parser.add_argument("--dir", default=".", help="Directory containing the PDFs")
+    parser.add_argument("--output", default="du_moore_parallel.jsonl")
+    args = parser.parse_args()
+
+    base = Path(args.dir)
+    all_records = []
+
+    for fname, book_num in PDFS:
+        path = base / fname
+        if not path.exists():
+            print(f"  [skip] {fname} not found")
+            continue
+        records = parse_pdf(path, book_num)
+        by_section: dict[str, int] = {}
+        for r in records:
+            by_section[r["section"]] = by_section.get(r["section"], 0) + 1
+        print(f"Book {book_num}: {len(records):>4} pairs  {by_section}")
+        all_records.extend(records)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        for r in all_records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    print(f"\nTotal: {len(all_records)} pairs → {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_pdfplumber.py
+++ b/test_pdfplumber.py
@@ -50,12 +50,14 @@ def extract_glossary_tables(pdf_path: str, pages: list[int] | None = None) -> li
                 df = pd.DataFrame(rows, columns=header)
                 print(df.to_string(index=False))
 
-                results.append({
-                    "page": page_num + 1,
-                    "table_index": i,
-                    "columns": header,
-                    "rows": rows,
-                })
+                results.append(
+                    {
+                        "page": page_num + 1,
+                        "table_index": i,
+                        "columns": header,
+                        "rows": rows,
+                    }
+                )
 
     return results
 


### PR DESCRIPTION
## Summary

- Adds `src/moore_web/parse_du_moore.py` to extract parallel French-Mooré sentence pairs from the three-book "Du Moore au Français" literacy series
- Pages are paired dynamically by matching consecutive pages with the same `Kaoreng … soaba` lesson header — no hard-coded page indices
- Supports two layouts: **sectioned** (①② markers, books 1-2 and early book 3) and **prose** (numbered vocab + reading passage, book 3 lessons 40-48)
- Outputs 941 parallel pairs to `du_moore_parallel.jsonl` across four section types: `key`, `vocab`, `sentences`, `conversation`/`passage`

## Key fixes
- Drop-cap letters that land in a separate y-bucket are re-attached to their sentence
- Empty vocab slots (`N –` with no value) are filtered out
- Two-digit item numbers (e.g. `17`) no longer get partially consumed — switched from `re.finditer` to `re.split`
- Subtitle lines skipped via `SUBTITLE_RE` + positional fallback so they are never returned as the key sentence
- Wrapped passage sentences merged across line boundaries

## Test plan
- [ ] Run `python3 src/moore_web/parse_du_moore.py` and verify output: `Book 1: 249`, `Book 2: 341`, `Book 3: 351`, `Total: 941 pairs`
- [ ] Spot-check `du_moore_parallel.jsonl` for correct French-Mooré alignment in `key`, `vocab`, `sentences`, and `passage` sections
- [ ] Verify book 2 lesson 1 (`Aoulatou a un joli bijou` / `A Aulatu tara bi-zãan neere`) is present — was previously skipped by hard-coded index